### PR TITLE
feat(types): Transaction, RawTransaction 型定義を追加

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 // Transaction
-export type { Transaction, TransactionType } from './transaction';
+export type { RawTransaction, Transaction, TransactionType } from './transaction';
 export { getTransactionType, isIncome, isExpense, isCalculated } from './transaction';
 
 // Summary

--- a/src/types/transaction.test.ts
+++ b/src/types/transaction.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { getTransactionType, isIncome, isExpense, isCalculated } from './transaction';
+import type { Transaction } from './transaction';
+
+// テスト用のTransaction作成ヘルパー
+function createTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'test-id',
+    date: new Date('2025-01-15'),
+    description: 'テスト取引',
+    amount: -1000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+    ...overrides,
+  };
+}
+
+describe('getTransactionType', () => {
+  it('正の金額は income を返す', () => {
+    expect(getTransactionType(1000)).toBe('income');
+  });
+
+  it('負の金額は expense を返す', () => {
+    expect(getTransactionType(-500)).toBe('expense');
+  });
+
+  it('ゼロは income を返す', () => {
+    expect(getTransactionType(0)).toBe('income');
+  });
+});
+
+describe('isIncome', () => {
+  it('正の金額の取引は true を返す', () => {
+    const transaction = createTransaction({ amount: 50000 });
+    expect(isIncome(transaction)).toBe(true);
+  });
+
+  it('負の金額の取引は false を返す', () => {
+    const transaction = createTransaction({ amount: -1000 });
+    expect(isIncome(transaction)).toBe(false);
+  });
+
+  it('ゼロの取引は false を返す', () => {
+    const transaction = createTransaction({ amount: 0 });
+    expect(isIncome(transaction)).toBe(false);
+  });
+});
+
+describe('isExpense', () => {
+  it('負の金額の取引は true を返す', () => {
+    const transaction = createTransaction({ amount: -1000 });
+    expect(isExpense(transaction)).toBe(true);
+  });
+
+  it('正の金額の取引は false を返す', () => {
+    const transaction = createTransaction({ amount: 50000 });
+    expect(isExpense(transaction)).toBe(false);
+  });
+
+  it('ゼロの取引は false を返す', () => {
+    const transaction = createTransaction({ amount: 0 });
+    expect(isExpense(transaction)).toBe(false);
+  });
+});
+
+describe('isCalculated', () => {
+  it('計算対象かつ振替でない取引は true を返す', () => {
+    const transaction = createTransaction({
+      isCalculated: true,
+      isTransfer: false,
+    });
+    expect(isCalculated(transaction)).toBe(true);
+  });
+
+  it('計算対象でない取引は false を返す', () => {
+    const transaction = createTransaction({
+      isCalculated: false,
+      isTransfer: false,
+    });
+    expect(isCalculated(transaction)).toBe(false);
+  });
+
+  it('振替の取引は false を返す', () => {
+    const transaction = createTransaction({
+      isCalculated: true,
+      isTransfer: true,
+    });
+    expect(isCalculated(transaction)).toBe(false);
+  });
+
+  it('計算対象でなく振替でもある取引は false を返す', () => {
+    const transaction = createTransaction({
+      isCalculated: false,
+      isTransfer: true,
+    });
+    expect(isCalculated(transaction)).toBe(false);
+  });
+});

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,0 +1,82 @@
+/**
+ * TSVから読み込んだ生データの型定義
+ */
+export type RawTransaction = {
+  計算対象: string;
+  日付: string;
+  内容: string;
+  '金額（円）': string;
+  保有金融機関: string;
+  大項目: string;
+  中項目: string;
+  メモ: string;
+  振替: string;
+  ID: string;
+};
+
+/**
+ * 変換後のトランザクション型定義
+ */
+export type Transaction = {
+  /** ユニークID */
+  id: string;
+  /** 取引日 */
+  date: Date;
+  /** 取引内容・説明 */
+  description: string;
+  /** 金額（正:収入、負:支出） */
+  amount: number;
+  /** 金融機関名 */
+  institution: string;
+  /** 大項目（カテゴリ） */
+  category: string;
+  /** 中項目（サブカテゴリ） */
+  subcategory: string;
+  /** メモ */
+  memo: string;
+  /** 振替フラグ */
+  isTransfer: boolean;
+  /** 計算対象フラグ */
+  isCalculated: boolean;
+};
+
+/**
+ * 取引の種別
+ */
+export type TransactionType = 'income' | 'expense';
+
+/**
+ * 取引の種別を判定
+ * @param amount 金額
+ * @returns 金額が0以上なら 'income'、負なら 'expense'
+ */
+export function getTransactionType(amount: number): TransactionType {
+  return amount >= 0 ? 'income' : 'expense';
+}
+
+/**
+ * 収入かどうかを判定
+ * @param transaction 取引
+ * @returns 金額が正なら true
+ */
+export function isIncome(transaction: Transaction): boolean {
+  return transaction.amount > 0;
+}
+
+/**
+ * 支出かどうかを判定
+ * @param transaction 取引
+ * @returns 金額が負なら true
+ */
+export function isExpense(transaction: Transaction): boolean {
+  return transaction.amount < 0;
+}
+
+/**
+ * 計算対象かどうかを判定
+ * @param transaction 取引
+ * @returns 計算対象フラグがtrueかつ振替でない場合 true
+ */
+export function isCalculated(transaction: Transaction): boolean {
+  return transaction.isCalculated && !transaction.isTransfer;
+}


### PR DESCRIPTION
## Summary
- RawTransaction型を追加: TSVから読み込んだ生データの型定義
- Transaction型を追加: 変換後のトランザクション型定義
- 型ガード関数を追加: getTransactionType, isIncome, isExpense, isCalculated

## Test plan
- [x] getTransactionType関数のテスト（正/負/ゼロ）
- [x] isIncome関数のテスト
- [x] isExpense関数のテスト
- [x] isCalculated関数のテスト
- [x] 全13テストケースがpass

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)