### PR TITLE
feat(services): dataLoader を追加

### DIFF
--- a/src/services/dataLoader.test.ts
+++ b/src/services/dataLoader.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadTSV } from './dataLoader';
+import { DataLoadError } from '@/schemas';
+
+describe('loadTSV', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('正常系', () => {
+    it('TSVファイルを読み込んで文字列を返す', async () => {
+      const mockTSV = '計算対象\t日付\t内容\n1\t2025/12/25\tテスト';
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(mockTSV),
+      });
+
+      const result = await loadTSV();
+
+      expect(result).toBe(mockTSV);
+      expect(fetch).toHaveBeenCalledWith('/data/data.tsv');
+    });
+  });
+
+  describe('異常系', () => {
+    it('HTTP 404エラーでDataLoadErrorをスロー', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      await expect(loadTSV()).rejects.toThrow(DataLoadError);
+      await expect(loadTSV()).rejects.toThrow('HTTP error: 404');
+    });
+
+    it('HTTP 500エラーでDataLoadErrorをスロー', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(loadTSV()).rejects.toThrow(DataLoadError);
+      await expect(loadTSV()).rejects.toThrow('HTTP error: 500');
+    });
+
+    it('ネットワークエラーでDataLoadErrorをスロー', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      await expect(loadTSV()).rejects.toThrow(DataLoadError);
+      await expect(loadTSV()).rejects.toThrow('Failed to load TSV file');
+    });
+
+    it('ネットワークエラー時にcauseが設定される', async () => {
+      const networkError = new Error('Network error');
+      global.fetch = vi.fn().mockRejectedValue(networkError);
+
+      try {
+        await loadTSV();
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(DataLoadError);
+        expect((error as DataLoadError).cause).toBe(networkError);
+      }
+    });
+  });
+});

--- a/src/services/dataLoader.ts
+++ b/src/services/dataLoader.ts
@@ -1,0 +1,23 @@
+import { DataLoadError } from '@/schemas';
+
+const DATA_PATH = '/data/data.tsv';
+
+/**
+ * TSVファイルを読み込む
+ * @returns TSV文字列
+ * @throws DataLoadError 読み込み失敗時
+ */
+export async function loadTSV(): Promise<string> {
+  try {
+    const response = await fetch(DATA_PATH);
+    if (!response.ok) {
+      throw new DataLoadError(`HTTP error: ${response.status}`);
+    }
+    return await response.text();
+  } catch (error) {
+    if (error instanceof DataLoadError) {
+      throw error;
+    }
+    throw new DataLoadError('Failed to load TSV file', error);
+  }
+}


### PR DESCRIPTION
## Summary
- loadTSV関数を実装: TSVファイル読み込み
- HTTPエラー時にDataLoadErrorをスロー
- ネットワークエラー時にcause付きでDataLoadErrorをスロー

## Test plan
- [x] 正常系: TSV文字列を返す
- [x] HTTP 404エラー時のテスト
- [x] HTTP 500エラー時のテスト
- [x] ネットワークエラー時のテスト
- [x] エラーのcauseプロパティのテスト
- [x] 全5テストケースがpass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)