### PR TITLE
feat(utils): cn ユーティリティを追加

### DIFF
--- a/src/utils/cn.test.ts
+++ b/src/utils/cn.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from './cn';
+
+describe('cn', () => {
+  describe('基本的なクラス結合', () => {
+    it('複数のクラス名を結合する', () => {
+      expect(cn('px-4', 'py-2', 'bg-white')).toBe('px-4 py-2 bg-white');
+    });
+
+    it('単一のクラス名を返す', () => {
+      expect(cn('px-4')).toBe('px-4');
+    });
+
+    it('空文字列を返す（引数なし）', () => {
+      expect(cn()).toBe('');
+    });
+  });
+
+  describe('条件付きクラス', () => {
+    it('trueの条件でクラスを含める', () => {
+      const isActive = true;
+      expect(cn('base', isActive && 'active')).toBe('base active');
+    });
+
+    it('falseの条件でクラスを除外する', () => {
+      const isActive = false;
+      expect(cn('base', isActive && 'active')).toBe('base');
+    });
+
+    it('undefinedを無視する', () => {
+      expect(cn('base', undefined, 'extra')).toBe('base extra');
+    });
+
+    it('nullを無視する', () => {
+      expect(cn('base', null, 'extra')).toBe('base extra');
+    });
+  });
+
+  describe('Tailwindクラスのマージ', () => {
+    it('パディングの競合を解決する', () => {
+      expect(cn('px-2 py-1', 'p-3')).toBe('p-3');
+    });
+
+    it('背景色の競合を解決する', () => {
+      expect(cn('bg-red-500', 'bg-blue-500')).toBe('bg-blue-500');
+    });
+
+    it('テキスト色の競合を解決する', () => {
+      expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+    });
+
+    it('後のクラスが優先される', () => {
+      expect(cn('font-bold', 'font-normal')).toBe('font-normal');
+    });
+
+    it('関係ないクラスは保持される', () => {
+      expect(cn('px-4 hover:bg-gray-100', 'py-2')).toBe('px-4 hover:bg-gray-100 py-2');
+    });
+  });
+
+  describe('配列のサポート', () => {
+    it('配列を展開する', () => {
+      expect(cn(['px-4', 'py-2'])).toBe('px-4 py-2');
+    });
+
+    it('ネストした配列を処理する', () => {
+      expect(cn('base', ['nested', ['deeply-nested']])).toBe('base nested deeply-nested');
+    });
+  });
+
+  describe('実際の使用例', () => {
+    it('ボタンのスタイルをマージする', () => {
+      const baseStyles = 'px-4 py-2 rounded font-medium';
+      const variantStyles = 'bg-primary text-white';
+      const userStyles = 'px-6'; // パディングを上書き
+
+      expect(cn(baseStyles, variantStyles, userStyles)).toBe(
+        'py-2 rounded font-medium bg-primary text-white px-6'
+      );
+    });
+
+    it('条件付きスタイルを適用する', () => {
+      const isDisabled = true;
+      const isLoading = false;
+
+      expect(
+        cn('btn', isDisabled && 'opacity-50 cursor-not-allowed', isLoading && 'animate-pulse')
+      ).toBe('btn opacity-50 cursor-not-allowed');
+    });
+  });
+});

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,13 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Tailwind CSSのクラス名を結合・マージ
+ * clsx + tailwind-merge のラッパー
+ * @param inputs クラス名（条件付き含む）
+ * @returns マージ済みクラス名
+ * @example cn('px-4', isActive && 'bg-primary', 'py-2') → "px-4 bg-primary py-2"
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- cn関数を実装: clsx + tailwind-merge のラッパー
- 条件付きクラス名のサポート
- Tailwind CSSクラスの競合を自動解決

## Test plan
- [x] 基本的なクラス結合テスト（3件）
- [x] 条件付きクラステスト（4件）
- [x] Tailwindクラスのマージテスト（5件）
- [x] 配列のサポートテスト（2件）
- [x] 実際の使用例テスト（2件）
- [x] 全16テストケースがpass

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)