### PR TITLE
feat(utils): filters を追加

### DIFF
--- a/src/utils/filters/amountFilter.test.ts
+++ b/src/utils/filters/amountFilter.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { filterByAmountRange, filterExpenses, filterIncomes } from './amountFilter';
+import type { Transaction } from '@/types';
+
+// テスト用のTransaction作成ヘルパー
+function createTransaction(amount: number): Transaction {
+  return {
+    id: 'test-id',
+    date: new Date('2025-01-15'),
+    description: 'テスト取引',
+    amount,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  };
+}
+
+describe('filterByAmountRange', () => {
+  const transactions = [
+    createTransaction(-5000),
+    createTransaction(-1000),
+    createTransaction(0),
+    createTransaction(1000),
+    createTransaction(50000),
+  ];
+
+  it('最小値と最大値の範囲内を抽出する', () => {
+    const result = filterByAmountRange(transactions, -2000, 2000);
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.amount)).toEqual([-1000, 0, 1000]);
+  });
+
+  it('最小値のみ指定できる', () => {
+    const result = filterByAmountRange(transactions, 0);
+    expect(result).toHaveLength(3);
+    expect(result.every((t) => t.amount >= 0)).toBe(true);
+  });
+
+  it('最大値のみ指定できる', () => {
+    const result = filterByAmountRange(transactions, undefined, 0);
+    expect(result).toHaveLength(3);
+    expect(result.every((t) => t.amount <= 0)).toBe(true);
+  });
+
+  it('両方undefinedなら全件返す', () => {
+    const result = filterByAmountRange(transactions);
+    expect(result).toHaveLength(5);
+  });
+
+  it('境界値を含む', () => {
+    const result = filterByAmountRange(transactions, -1000, 1000);
+    expect(result.map((t) => t.amount)).toContain(-1000);
+    expect(result.map((t) => t.amount)).toContain(1000);
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const result = filterByAmountRange(transactions, 100000, 200000);
+    expect(result).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterByAmountRange([], -1000, 1000)).toEqual([]);
+  });
+});
+
+describe('filterExpenses', () => {
+  const transactions = [
+    createTransaction(-5000),
+    createTransaction(-1000),
+    createTransaction(0),
+    createTransaction(1000),
+    createTransaction(50000),
+  ];
+
+  it('支出（負の金額）のみを抽出する', () => {
+    const result = filterExpenses(transactions);
+    expect(result).toHaveLength(2);
+    result.forEach((t) => {
+      expect(t.amount).toBeLessThan(0);
+    });
+  });
+
+  it('支出がなければ空配列を返す', () => {
+    const txs = [createTransaction(0), createTransaction(1000)];
+    expect(filterExpenses(txs)).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterExpenses([])).toEqual([]);
+  });
+});
+
+describe('filterIncomes', () => {
+  const transactions = [
+    createTransaction(-5000),
+    createTransaction(-1000),
+    createTransaction(0),
+    createTransaction(1000),
+    createTransaction(50000),
+  ];
+
+  it('収入（正の金額）のみを抽出する', () => {
+    const result = filterIncomes(transactions);
+    expect(result).toHaveLength(2);
+    result.forEach((t) => {
+      expect(t.amount).toBeGreaterThan(0);
+    });
+  });
+
+  it('収入がなければ空配列を返す', () => {
+    const txs = [createTransaction(0), createTransaction(-1000)];
+    expect(filterIncomes(txs)).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterIncomes([])).toEqual([]);
+  });
+});

--- a/src/utils/filters/amountFilter.ts
+++ b/src/utils/filters/amountFilter.ts
@@ -1,0 +1,42 @@
+import type { Transaction } from '@/types';
+
+/**
+ * 金額範囲でフィルタ
+ * @param transactions トランザクション配列
+ * @param min 最小金額（undefined の場合は下限なし）
+ * @param max 最大金額（undefined の場合は上限なし）
+ * @returns フィルター済み配列
+ */
+export function filterByAmountRange(
+  transactions: Transaction[],
+  min?: number,
+  max?: number
+): Transaction[] {
+  return transactions.filter((t) => {
+    if (min !== undefined && t.amount < min) {
+      return false;
+    }
+    if (max !== undefined && t.amount > max) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * 支出のみを抽出（負の金額）
+ * @param transactions トランザクション配列
+ * @returns 支出のみの配列
+ */
+export function filterExpenses(transactions: Transaction[]): Transaction[] {
+  return transactions.filter((t) => t.amount < 0);
+}
+
+/**
+ * 収入のみを抽出（正の金額）
+ * @param transactions トランザクション配列
+ * @returns 収入のみの配列
+ */
+export function filterIncomes(transactions: Transaction[]): Transaction[] {
+  return transactions.filter((t) => t.amount > 0);
+}

--- a/src/utils/filters/categoryFilter.test.ts
+++ b/src/utils/filters/categoryFilter.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterByCategory,
+  filterBySubcategory,
+  filterByInstitution,
+  filterBySearchQuery,
+} from './categoryFilter';
+import type { Transaction } from '@/types';
+
+// テスト用のTransaction作成ヘルパー
+function createTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'test-id',
+    date: new Date('2025-01-15'),
+    description: 'テスト取引',
+    amount: -1000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+    ...overrides,
+  };
+}
+
+describe('filterByCategory', () => {
+  const transactions = [
+    createTransaction({ category: '食費' }),
+    createTransaction({ category: '食費' }),
+    createTransaction({ category: '交通費' }),
+    createTransaction({ category: '日用品' }),
+  ];
+
+  it('指定したカテゴリのトランザクションを抽出する', () => {
+    const result = filterByCategory(transactions, '食費');
+    expect(result).toHaveLength(2);
+    result.forEach((t) => {
+      expect(t.category).toBe('食費');
+    });
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const result = filterByCategory(transactions, '医療費');
+    expect(result).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterByCategory([], '食費')).toEqual([]);
+  });
+});
+
+describe('filterBySubcategory', () => {
+  const transactions = [
+    createTransaction({ subcategory: '食料品' }),
+    createTransaction({ subcategory: '食料品' }),
+    createTransaction({ subcategory: '外食' }),
+    createTransaction({ subcategory: 'カフェ' }),
+  ];
+
+  it('指定した中項目のトランザクションを抽出する', () => {
+    const result = filterBySubcategory(transactions, '食料品');
+    expect(result).toHaveLength(2);
+    result.forEach((t) => {
+      expect(t.subcategory).toBe('食料品');
+    });
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const result = filterBySubcategory(transactions, 'コンビニ');
+    expect(result).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterBySubcategory([], '食料品')).toEqual([]);
+  });
+});
+
+describe('filterByInstitution', () => {
+  const transactions = [
+    createTransaction({ institution: '三菱UFJ銀行' }),
+    createTransaction({ institution: '三菱UFJ銀行' }),
+    createTransaction({ institution: '楽天カード' }),
+    createTransaction({ institution: 'PayPay' }),
+  ];
+
+  it('指定した金融機関のトランザクションを抽出する', () => {
+    const result = filterByInstitution(transactions, '三菱UFJ銀行');
+    expect(result).toHaveLength(2);
+    result.forEach((t) => {
+      expect(t.institution).toBe('三菱UFJ銀行');
+    });
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const result = filterByInstitution(transactions, 'みずほ銀行');
+    expect(result).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterByInstitution([], '三菱UFJ銀行')).toEqual([]);
+  });
+});
+
+describe('filterBySearchQuery', () => {
+  const transactions = [
+    createTransaction({ description: 'スーパーマーケット' }),
+    createTransaction({ description: 'コンビニ購入' }),
+    createTransaction({ description: 'マルエツ鹿島田店' }),
+    createTransaction({ description: '電車賃' }),
+  ];
+
+  it('説明に検索文字列を含むトランザクションを抽出する', () => {
+    const result = filterBySearchQuery(transactions, 'マーケット');
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('スーパーマーケット');
+  });
+
+  it('大文字小文字を区別しない', () => {
+    const txs = [createTransaction({ description: 'VISA CARD' })];
+    const result = filterBySearchQuery(txs, 'visa');
+    expect(result).toHaveLength(1);
+  });
+
+  it('部分一致で検索する', () => {
+    const result = filterBySearchQuery(transactions, 'コンビニ');
+    expect(result).toHaveLength(1);
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const result = filterBySearchQuery(transactions, 'ガソリン');
+    expect(result).toEqual([]);
+  });
+
+  it('空の検索文字列は全件返す', () => {
+    const result = filterBySearchQuery(transactions, '');
+    expect(result).toHaveLength(4);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterBySearchQuery([], 'test')).toEqual([]);
+  });
+});

--- a/src/utils/filters/categoryFilter.ts
+++ b/src/utils/filters/categoryFilter.ts
@@ -1,0 +1,51 @@
+import type { Transaction } from '@/types';
+
+/**
+ * カテゴリでフィルタ
+ * @param transactions トランザクション配列
+ * @param category カテゴリ名
+ * @returns フィルター済み配列
+ */
+export function filterByCategory(transactions: Transaction[], category: string): Transaction[] {
+  return transactions.filter((t) => t.category === category);
+}
+
+/**
+ * 中項目でフィルタ
+ * @param transactions トランザクション配列
+ * @param subcategory 中項目名
+ * @returns フィルター済み配列
+ */
+export function filterBySubcategory(
+  transactions: Transaction[],
+  subcategory: string
+): Transaction[] {
+  return transactions.filter((t) => t.subcategory === subcategory);
+}
+
+/**
+ * 金融機関でフィルタ
+ * @param transactions トランザクション配列
+ * @param institution 金融機関名
+ * @returns フィルター済み配列
+ */
+export function filterByInstitution(
+  transactions: Transaction[],
+  institution: string
+): Transaction[] {
+  return transactions.filter((t) => t.institution === institution);
+}
+
+/**
+ * 検索クエリでフィルタ（説明文の部分一致、大文字小文字区別なし）
+ * @param transactions トランザクション配列
+ * @param query 検索文字列
+ * @returns フィルター済み配列
+ */
+export function filterBySearchQuery(transactions: Transaction[], query: string): Transaction[] {
+  if (!query) {
+    return transactions;
+  }
+  const lowerQuery = query.toLowerCase();
+  return transactions.filter((t) => t.description.toLowerCase().includes(lowerQuery));
+}

--- a/src/utils/filters/dateFilter.test.ts
+++ b/src/utils/filters/dateFilter.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { filterByMonth, filterByYear, filterByDateRange } from './dateFilter';
+import type { Transaction } from '@/types';
+
+// テスト用のTransaction作成ヘルパー
+function createTransaction(date: Date): Transaction {
+  return {
+    id: 'test-id',
+    date,
+    description: 'テスト取引',
+    amount: -1000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  };
+}
+
+describe('filterByMonth', () => {
+  const transactions = [
+    createTransaction(new Date('2025-01-15')),
+    createTransaction(new Date('2025-01-20')),
+    createTransaction(new Date('2025-02-10')),
+    createTransaction(new Date('2025-12-25')),
+  ];
+
+  it('指定した年月のトランザクションを抽出する', () => {
+    const result = filterByMonth(transactions, 2025, 1);
+    expect(result).toHaveLength(2);
+    result.forEach((t) => {
+      expect(t.date.getFullYear()).toBe(2025);
+      expect(t.date.getMonth() + 1).toBe(1);
+    });
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const result = filterByMonth(transactions, 2025, 6);
+    expect(result).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterByMonth([], 2025, 1)).toEqual([]);
+  });
+});
+
+describe('filterByYear', () => {
+  const transactions = [
+    createTransaction(new Date('2024-12-31')),
+    createTransaction(new Date('2025-01-01')),
+    createTransaction(new Date('2025-06-15')),
+    createTransaction(new Date('2026-01-01')),
+  ];
+
+  it('指定した年のトランザクションを抽出する', () => {
+    const result = filterByYear(transactions, 2025);
+    expect(result).toHaveLength(2);
+    result.forEach((t) => {
+      expect(t.date.getFullYear()).toBe(2025);
+    });
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const result = filterByYear(transactions, 2023);
+    expect(result).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterByYear([], 2025)).toEqual([]);
+  });
+});
+
+describe('filterByDateRange', () => {
+  const transactions = [
+    createTransaction(new Date('2025-01-01')),
+    createTransaction(new Date('2025-01-15')),
+    createTransaction(new Date('2025-01-31')),
+    createTransaction(new Date('2025-02-01')),
+  ];
+
+  it('指定した期間のトランザクションを抽出する', () => {
+    const start = new Date('2025-01-10');
+    const end = new Date('2025-01-31');
+    const result = filterByDateRange(transactions, start, end);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('境界値を含む', () => {
+    const start = new Date('2025-01-15');
+    const end = new Date('2025-01-31');
+    const result = filterByDateRange(transactions, start, end);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].date).toEqual(new Date('2025-01-15'));
+    expect(result[1].date).toEqual(new Date('2025-01-31'));
+  });
+
+  it('該当がなければ空配列を返す', () => {
+    const start = new Date('2025-03-01');
+    const end = new Date('2025-03-31');
+    const result = filterByDateRange(transactions, start, end);
+    expect(result).toEqual([]);
+  });
+
+  it('空配列は空配列を返す', () => {
+    expect(filterByDateRange([], new Date(), new Date())).toEqual([]);
+  });
+});

--- a/src/utils/filters/dateFilter.ts
+++ b/src/utils/filters/dateFilter.ts
@@ -1,0 +1,44 @@
+import type { Transaction } from '@/types';
+
+/**
+ * 特定月のデータを抽出
+ * @param transactions トランザクション配列
+ * @param year 年
+ * @param month 月（1-12）
+ * @returns フィルター済み配列
+ */
+export function filterByMonth(
+  transactions: Transaction[],
+  year: number,
+  month: number
+): Transaction[] {
+  return transactions.filter((t) => {
+    const d = t.date;
+    return d.getFullYear() === year && d.getMonth() + 1 === month;
+  });
+}
+
+/**
+ * 特定年のデータを抽出
+ * @param transactions トランザクション配列
+ * @param year 年
+ * @returns フィルター済み配列
+ */
+export function filterByYear(transactions: Transaction[], year: number): Transaction[] {
+  return transactions.filter((t) => t.date.getFullYear() === year);
+}
+
+/**
+ * 期間でフィルタ
+ * @param transactions トランザクション配列
+ * @param start 開始日
+ * @param end 終了日
+ * @returns フィルター済み配列
+ */
+export function filterByDateRange(
+  transactions: Transaction[],
+  start: Date,
+  end: Date
+): Transaction[] {
+  return transactions.filter((t) => t.date >= start && t.date <= end);
+}


### PR DESCRIPTION
## Summary
- dateFilter: 日付フィルター（月、年、期間）
- categoryFilter: カテゴリフィルター（大項目、中項目、金融機関、検索クエリ）
- amountFilter: 金額フィルター（範囲、支出のみ、収入のみ）

## Test plan
- [x] dateFilterテスト（10件）
- [x] categoryFilterテスト（15件）
- [x] amountFilterテスト（13件）
- [x] 全38テストケースがpass

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)