### PR TITLE
feat(constants): 定数ファイル実装 (Issue #9)

### DIFF
--- a/src/constants/breakpoints.test.ts
+++ b/src/constants/breakpoints.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { BREAKPOINTS, isBreakpoint } from './breakpoints';
+
+describe('BREAKPOINTS', () => {
+  it('sm (Mobile) が640pxで定義されている', () => {
+    expect(BREAKPOINTS.sm).toBe(640);
+  });
+
+  it('md (Tablet) が768pxで定義されている', () => {
+    expect(BREAKPOINTS.md).toBe(768);
+  });
+
+  it('lg (Desktop) が1024pxで定義されている', () => {
+    expect(BREAKPOINTS.lg).toBe(1024);
+  });
+
+  it('xl (Wide) が1280pxで定義されている', () => {
+    expect(BREAKPOINTS.xl).toBe(1280);
+  });
+
+  it('2xl が1536pxで定義されている', () => {
+    expect(BREAKPOINTS['2xl']).toBe(1536);
+  });
+});
+
+describe('isBreakpoint', () => {
+  describe('sm', () => {
+    it('639pxはsmより小さい', () => {
+      expect(isBreakpoint(639, 'sm')).toBe(false);
+    });
+
+    it('640pxはsm以上', () => {
+      expect(isBreakpoint(640, 'sm')).toBe(true);
+    });
+  });
+
+  describe('md', () => {
+    it('767pxはmdより小さい', () => {
+      expect(isBreakpoint(767, 'md')).toBe(false);
+    });
+
+    it('768pxはmd以上', () => {
+      expect(isBreakpoint(768, 'md')).toBe(true);
+    });
+  });
+
+  describe('lg', () => {
+    it('1023pxはlgより小さい', () => {
+      expect(isBreakpoint(1023, 'lg')).toBe(false);
+    });
+
+    it('1024pxはlg以上', () => {
+      expect(isBreakpoint(1024, 'lg')).toBe(true);
+    });
+  });
+
+  describe('xl', () => {
+    it('1279pxはxlより小さい', () => {
+      expect(isBreakpoint(1279, 'xl')).toBe(false);
+    });
+
+    it('1280pxはxl以上', () => {
+      expect(isBreakpoint(1280, 'xl')).toBe(true);
+    });
+  });
+});

--- a/src/constants/breakpoints.ts
+++ b/src/constants/breakpoints.ts
@@ -1,0 +1,57 @@
+/**
+ * レスポンシブブレークポイント定義
+ * Tailwind CSSのデフォルト値に準拠
+ * @see doc/design_theme.md レスポンシブブレークポイント
+ */
+
+export type BreakpointKey = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+/**
+ * ブレークポイント（ピクセル値）
+ * - sm: 640px（Mobile上限）
+ * - md: 768px（Tablet開始）
+ * - lg: 1024px（Desktop開始）
+ * - xl: 1280px（Wide開始）
+ * - 2xl: 1536px（超ワイド）
+ */
+export const BREAKPOINTS: Record<BreakpointKey, number> = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536,
+} as const;
+
+/**
+ * 画面幅が指定したブレークポイント以上かを判定
+ * @param width 画面幅（ピクセル）
+ * @param breakpoint ブレークポイントキー
+ * @returns 指定したブレークポイント以上であればtrue
+ */
+export function isBreakpoint(width: number, breakpoint: BreakpointKey): boolean {
+  return width >= BREAKPOINTS[breakpoint];
+}
+
+/**
+ * 現在のブレークポイントを取得
+ * @param width 画面幅（ピクセル）
+ * @returns 現在のブレークポイントキー
+ */
+export function getCurrentBreakpoint(width: number): BreakpointKey | null {
+  if (width >= BREAKPOINTS['2xl']) {
+    return '2xl';
+  }
+  if (width >= BREAKPOINTS.xl) {
+    return 'xl';
+  }
+  if (width >= BREAKPOINTS.lg) {
+    return 'lg';
+  }
+  if (width >= BREAKPOINTS.md) {
+    return 'md';
+  }
+  if (width >= BREAKPOINTS.sm) {
+    return 'sm';
+  }
+  return null; // Mobile (< 640px)
+}

--- a/src/constants/categories.test.ts
+++ b/src/constants/categories.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { CATEGORIES, getCategoryColor, getCategoryIcon } from './categories';
+
+describe('CATEGORIES', () => {
+  it('食費の定義が存在する', () => {
+    const category = CATEGORIES['食費'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#F59E0B');
+    expect(category?.icon).toBe('utensils');
+  });
+
+  it('日用品の定義が存在する', () => {
+    const category = CATEGORIES['日用品'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#8B5CF6');
+    expect(category?.icon).toBe('shopping-bag');
+  });
+
+  it('交通費の定義が存在する', () => {
+    const category = CATEGORIES['交通費'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#3B82F6');
+    expect(category?.icon).toBe('train');
+  });
+
+  it('通信費の定義が存在する', () => {
+    const category = CATEGORIES['通信費'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#06B6D4');
+    expect(category?.icon).toBe('smartphone');
+  });
+
+  it('教養・教育の定義が存在する', () => {
+    const category = CATEGORIES['教養・教育'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#10B981');
+    expect(category?.icon).toBe('book-open');
+  });
+
+  it('健康・医療の定義が存在する', () => {
+    const category = CATEGORIES['健康・医療'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#EC4899');
+    expect(category?.icon).toBe('heart-pulse');
+  });
+
+  it('衣服・美容の定義が存在する', () => {
+    const category = CATEGORIES['衣服・美容'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#F97316');
+    expect(category?.icon).toBe('shirt');
+  });
+
+  it('趣味・娯楽の定義が存在する', () => {
+    const category = CATEGORIES['趣味・娯楽'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#6366F1');
+    expect(category?.icon).toBe('gamepad-2');
+  });
+
+  it('水道・光熱費の定義が存在する', () => {
+    const category = CATEGORIES['水道・光熱費'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#14B8A6');
+    expect(category?.icon).toBe('zap');
+  });
+
+  it('交際費の定義が存在する', () => {
+    const category = CATEGORIES['交際費'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#EF4444');
+    expect(category?.icon).toBe('users');
+  });
+
+  it('その他の定義が存在する', () => {
+    const category = CATEGORIES['その他'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#6B7280');
+    expect(category?.icon).toBe('more-horizontal');
+  });
+
+  it('収入の定義が存在する', () => {
+    const category = CATEGORIES['収入'];
+    expect(category).toBeDefined();
+    expect(category?.color).toBe('#059669');
+    expect(category?.icon).toBe('arrow-up-circle');
+  });
+});
+
+describe('getCategoryColor', () => {
+  it('存在するカテゴリの色を返す', () => {
+    expect(getCategoryColor('食費')).toBe('#F59E0B');
+    expect(getCategoryColor('日用品')).toBe('#8B5CF6');
+    expect(getCategoryColor('交通費')).toBe('#3B82F6');
+  });
+
+  it('存在しないカテゴリはその他の色を返す', () => {
+    expect(getCategoryColor('未知のカテゴリ')).toBe('#6B7280');
+  });
+});
+
+describe('getCategoryIcon', () => {
+  it('存在するカテゴリのアイコン名を返す', () => {
+    expect(getCategoryIcon('食費')).toBe('utensils');
+    expect(getCategoryIcon('日用品')).toBe('shopping-bag');
+    expect(getCategoryIcon('交通費')).toBe('train');
+  });
+
+  it('存在しないカテゴリはその他のアイコンを返す', () => {
+    expect(getCategoryIcon('未知のカテゴリ')).toBe('more-horizontal');
+  });
+});

--- a/src/constants/categories.ts
+++ b/src/constants/categories.ts
@@ -1,0 +1,52 @@
+/**
+ * カテゴリ定義
+ * 色とアイコンの情報を含む
+ */
+
+export type CategoryInfo = {
+  color: string;
+  icon: string;
+};
+
+/**
+ * カテゴリ別の定義（色・アイコン）
+ * @see doc/design_theme.md チャートカラー
+ */
+export const CATEGORIES: Record<string, CategoryInfo> = {
+  食費: { color: '#F59E0B', icon: 'utensils' },
+  日用品: { color: '#8B5CF6', icon: 'shopping-bag' },
+  交通費: { color: '#3B82F6', icon: 'train' },
+  通信費: { color: '#06B6D4', icon: 'smartphone' },
+  '教養・教育': { color: '#10B981', icon: 'book-open' },
+  '健康・医療': { color: '#EC4899', icon: 'heart-pulse' },
+  '衣服・美容': { color: '#F97316', icon: 'shirt' },
+  '趣味・娯楽': { color: '#6366F1', icon: 'gamepad-2' },
+  '水道・光熱費': { color: '#14B8A6', icon: 'zap' },
+  交際費: { color: '#EF4444', icon: 'users' },
+  その他: { color: '#6B7280', icon: 'more-horizontal' },
+  収入: { color: '#059669', icon: 'arrow-up-circle' },
+} as const;
+
+/** その他カテゴリのデフォルト色 */
+const DEFAULT_COLOR = '#6B7280';
+
+/** その他カテゴリのデフォルトアイコン */
+const DEFAULT_ICON = 'more-horizontal';
+
+/**
+ * カテゴリの色を取得
+ * @param category カテゴリ名
+ * @returns HEXカラーコード（未定義の場合は「その他」の色）
+ */
+export function getCategoryColor(category: string): string {
+  return CATEGORIES[category]?.color ?? DEFAULT_COLOR;
+}
+
+/**
+ * カテゴリのアイコン名を取得
+ * @param category カテゴリ名
+ * @returns Lucide Iconアイコン名（未定義の場合は「その他」のアイコン）
+ */
+export function getCategoryIcon(category: string): string {
+  return CATEGORIES[category]?.icon ?? DEFAULT_ICON;
+}

--- a/src/constants/chartColors.test.ts
+++ b/src/constants/chartColors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { CHART_COLORS, TREND_COLORS, SEMANTIC_COLORS } from './chartColors';
+
+describe('CHART_COLORS', () => {
+  it('income色が定義されている', () => {
+    expect(CHART_COLORS.income).toBe('#059669');
+  });
+
+  it('expense色が定義されている', () => {
+    expect(CHART_COLORS.expense).toBe('#DC2626');
+  });
+
+  it('balance色が定義されている', () => {
+    expect(CHART_COLORS.balance).toBe('#2D6A4F');
+  });
+});
+
+describe('TREND_COLORS', () => {
+  it('income色が定義されている', () => {
+    expect(TREND_COLORS.income).toBe('#059669');
+  });
+
+  it('expense色が定義されている', () => {
+    expect(TREND_COLORS.expense).toBe('#DC2626');
+  });
+
+  it('balance色が定義されている', () => {
+    expect(TREND_COLORS.balance).toBe('#2D6A4F');
+  });
+});
+
+describe('SEMANTIC_COLORS', () => {
+  it('income関連の色が定義されている', () => {
+    expect(SEMANTIC_COLORS.income).toBe('#059669');
+    expect(SEMANTIC_COLORS.incomeLight).toBe('#D1FAE5');
+  });
+
+  it('expense関連の色が定義されている', () => {
+    expect(SEMANTIC_COLORS.expense).toBe('#DC2626');
+    expect(SEMANTIC_COLORS.expenseLight).toBe('#FEE2E2');
+  });
+
+  it('neutral色が定義されている', () => {
+    expect(SEMANTIC_COLORS.neutral).toBe('#6B7280');
+  });
+
+  it('warning関連の色が定義されている', () => {
+    expect(SEMANTIC_COLORS.warning).toBe('#D97706');
+    expect(SEMANTIC_COLORS.warningLight).toBe('#FEF3C7');
+  });
+});

--- a/src/constants/chartColors.ts
+++ b/src/constants/chartColors.ts
@@ -1,0 +1,74 @@
+/**
+ * チャートカラー定義
+ * @see doc/design_theme.md
+ */
+
+/**
+ * 収支推移グラフ用カラー
+ */
+export const CHART_COLORS = {
+  income: '#059669',
+  expense: '#DC2626',
+  balance: '#2D6A4F',
+} as const;
+
+/**
+ * トレンドチャート用カラー
+ */
+export const TREND_COLORS = {
+  income: '#059669',
+  expense: '#DC2626',
+  balance: '#2D6A4F',
+} as const;
+
+/**
+ * セマンティックカラー（意味を持つ色）
+ */
+export const SEMANTIC_COLORS = {
+  income: '#059669',
+  incomeLight: '#D1FAE5',
+  expense: '#DC2626',
+  expenseLight: '#FEE2E2',
+  neutral: '#6B7280',
+  warning: '#D97706',
+  warningLight: '#FEF3C7',
+} as const;
+
+/**
+ * プライマリカラー
+ */
+export const PRIMARY_COLORS = {
+  primary: '#2D6A4F',
+  primaryLight: '#40916C',
+  primaryDark: '#1B4332',
+} as const;
+
+/**
+ * セカンダリカラー
+ */
+export const SECONDARY_COLORS = {
+  secondary: '#B07D62',
+  secondaryLight: '#D4A574',
+  secondaryDark: '#8B5E3C',
+} as const;
+
+/**
+ * ベースカラー
+ */
+export const BASE_COLORS = {
+  background: '#FDFBF7',
+  surface: '#FFFFFF',
+  surfaceHover: '#F9F7F3',
+  border: '#E5E1D8',
+  borderStrong: '#D1CCC0',
+} as const;
+
+/**
+ * テキストカラー
+ */
+export const TEXT_COLORS = {
+  primary: '#1F2937',
+  secondary: '#6B7280',
+  tertiary: '#9CA3AF',
+  onPrimary: '#FFFFFF',
+} as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,22 @@
+// カテゴリ定義
+export { CATEGORIES, getCategoryColor, getCategoryIcon } from './categories';
+export type { CategoryInfo } from './categories';
+
+// チャートカラー
+export {
+  CHART_COLORS,
+  TREND_COLORS,
+  SEMANTIC_COLORS,
+  PRIMARY_COLORS,
+  SECONDARY_COLORS,
+  BASE_COLORS,
+  TEXT_COLORS,
+} from './chartColors';
+
+// 金融機関
+export { INSTITUTIONS, getInstitutionShortName, getInstitutionType } from './institutions';
+export type { InstitutionInfo, InstitutionType } from './institutions';
+
+// ブレークポイント
+export { BREAKPOINTS, isBreakpoint, getCurrentBreakpoint } from './breakpoints';
+export type { BreakpointKey } from './breakpoints';

--- a/src/constants/institutions.test.ts
+++ b/src/constants/institutions.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { INSTITUTIONS, getInstitutionShortName } from './institutions';
+
+describe('INSTITUTIONS', () => {
+  it('三菱UFJ銀行の定義が存在する', () => {
+    const inst = INSTITUTIONS['三菱UFJ銀行'];
+    expect(inst).toBeDefined();
+    expect(inst?.shortName).toBe('三菱UFJ');
+    expect(inst?.type).toBe('bank');
+  });
+
+  it('楽天カードの定義が存在する', () => {
+    const inst = INSTITUTIONS['楽天カード'];
+    expect(inst).toBeDefined();
+    expect(inst?.shortName).toBe('楽天');
+    expect(inst?.type).toBe('card');
+  });
+
+  it('三井住友カードの定義が存在する', () => {
+    const inst = INSTITUTIONS['三井住友カード'];
+    expect(inst).toBeDefined();
+    expect(inst?.shortName).toBe('三井住友');
+    expect(inst?.type).toBe('card');
+  });
+
+  it('PayPayの定義が存在する', () => {
+    const inst = INSTITUTIONS['PayPay'];
+    expect(inst).toBeDefined();
+    expect(inst?.shortName).toBe('PayPay');
+    expect(inst?.type).toBe('epay');
+  });
+
+  it('みずほ銀行の定義が存在する', () => {
+    const inst = INSTITUTIONS['みずほ銀行'];
+    expect(inst).toBeDefined();
+    expect(inst?.shortName).toBe('みずほ');
+    expect(inst?.type).toBe('bank');
+  });
+
+  it('現金の定義が存在する', () => {
+    const inst = INSTITUTIONS['現金'];
+    expect(inst).toBeDefined();
+    expect(inst?.shortName).toBe('現金');
+    expect(inst?.type).toBe('cash');
+  });
+});
+
+describe('getInstitutionShortName', () => {
+  it('存在する金融機関の短縮名を返す', () => {
+    expect(getInstitutionShortName('三菱UFJ銀行')).toBe('三菱UFJ');
+    expect(getInstitutionShortName('楽天カード')).toBe('楽天');
+    expect(getInstitutionShortName('PayPay')).toBe('PayPay');
+  });
+
+  it('存在しない金融機関は元の名前を返す', () => {
+    expect(getInstitutionShortName('未知の銀行')).toBe('未知の銀行');
+  });
+});

--- a/src/constants/institutions.ts
+++ b/src/constants/institutions.ts
@@ -1,0 +1,49 @@
+/**
+ * 金融機関定義
+ */
+
+export type InstitutionType = 'bank' | 'card' | 'epay' | 'cash' | 'other';
+
+export type InstitutionInfo = {
+  shortName: string;
+  type: InstitutionType;
+};
+
+/**
+ * 金融機関の定義（短縮名・種別）
+ */
+export const INSTITUTIONS: Record<string, InstitutionInfo> = {
+  三菱UFJ銀行: { shortName: '三菱UFJ', type: 'bank' },
+  みずほ銀行: { shortName: 'みずほ', type: 'bank' },
+  三井住友銀行: { shortName: '三井住友', type: 'bank' },
+  ゆうちょ銀行: { shortName: 'ゆうちょ', type: 'bank' },
+  楽天銀行: { shortName: '楽天', type: 'bank' },
+  住信SBIネット銀行: { shortName: 'SBI', type: 'bank' },
+  楽天カード: { shortName: '楽天', type: 'card' },
+  三井住友カード: { shortName: '三井住友', type: 'card' },
+  JCBカード: { shortName: 'JCB', type: 'card' },
+  アメックス: { shortName: 'AMEX', type: 'card' },
+  PayPay: { shortName: 'PayPay', type: 'epay' },
+  'LINE Pay': { shortName: 'LINE', type: 'epay' },
+  楽天ペイ: { shortName: '楽天Pay', type: 'epay' },
+  d払い: { shortName: 'd払い', type: 'epay' },
+  現金: { shortName: '現金', type: 'cash' },
+} as const;
+
+/**
+ * 金融機関の短縮名を取得
+ * @param institution 金融機関名
+ * @returns 短縮名（未定義の場合は元の名前をそのまま返す）
+ */
+export function getInstitutionShortName(institution: string): string {
+  return INSTITUTIONS[institution]?.shortName ?? institution;
+}
+
+/**
+ * 金融機関の種別を取得
+ * @param institution 金融機関名
+ * @returns 種別（未定義の場合は'other'）
+ */
+export function getInstitutionType(institution: string): InstitutionType {
+  return INSTITUTIONS[institution]?.type ?? 'other';
+}


### PR DESCRIPTION
## Summary

- categories.ts: カテゴリ定義（色・アイコン）とヘルパー関数を実装
- chartColors.ts: チャート用カラー・セマンティックカラー定義を実装
- institutions.ts: 金融機関定義と短縮名取得関数を実装
- breakpoints.ts: レスポンシブブレークポイント定義を実装
- index.ts: 一括エクスポート

## Test Plan

- [x] 47件の単体テストを追加し全てパス
- [x] カテゴリ12種類の色・アイコン定義テスト
- [x] getCategoryColor/getCategoryIcon関数のテスト
- [x] 金融機関6種類の定義テスト
- [x] getInstitutionShortName関数のテスト
- [x] ブレークポイント5種類の定義テスト
- [x] isBreakpoint関数のテスト
- [x] CHART_COLORS/TREND_COLORS/SEMANTIC_COLORSのテスト

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)