### PR TITLE
feat(ui): Buttonコンポーネント実装 (Issue #10)

### DIFF
--- a/src/components/ui/Button/Button.test.tsx
+++ b/src/components/ui/Button/Button.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from './Button';
+
+describe('Button', () => {
+  describe('レンダリング', () => {
+    it('子要素を正しくレンダリングする', () => {
+      render(<Button>Click me</Button>);
+      expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+    });
+  });
+
+  describe('variant', () => {
+    it('primaryがデフォルトで適用される', () => {
+      render(<Button>Primary</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('bg-primary');
+    });
+
+    it('secondaryスタイルが適用される', () => {
+      render(<Button variant="secondary">Secondary</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('border');
+      expect(button).toHaveClass('border-primary');
+    });
+
+    it('ghostスタイルが適用される', () => {
+      render(<Button variant="ghost">Ghost</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('text-primary');
+    });
+  });
+
+  describe('size', () => {
+    it('mdがデフォルトで適用される', () => {
+      render(<Button>Medium</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('px-5');
+      expect(button).toHaveClass('py-2.5');
+    });
+
+    it('smサイズが適用される', () => {
+      render(<Button size="sm">Small</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('px-3');
+      expect(button).toHaveClass('py-1.5');
+    });
+
+    it('lgサイズが適用される', () => {
+      render(<Button size="lg">Large</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('px-6');
+      expect(button).toHaveClass('py-3');
+    });
+  });
+
+  describe('disabled', () => {
+    it('disabled属性が正しく設定される', () => {
+      render(<Button disabled>Disabled</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+    });
+
+    it('disabled時は半透明スタイルが適用される', () => {
+      render(<Button disabled>Disabled</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('opacity-50');
+      expect(button).toHaveClass('cursor-not-allowed');
+    });
+
+    it('disabled時はクリックできない', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Button disabled onClick={handleClick}>
+          Disabled
+        </Button>
+      );
+
+      await user.click(screen.getByRole('button'));
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onClick', () => {
+    it('クリック時にハンドラーが呼ばれる', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(<Button onClick={handleClick}>Click me</Button>);
+
+      await user.click(screen.getByRole('button'));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('追加属性', () => {
+    it('type属性を渡せる', () => {
+      render(<Button type="submit">Submit</Button>);
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+    });
+
+    it('カスタムclassNameを追加できる', () => {
+      render(<Button className="custom-class">Custom</Button>);
+      const button = screen.getByRole('button');
+      expect(button).toHaveClass('custom-class');
+    });
+  });
+});

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/utils';
+
+type ButtonProps = {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  children: React.ReactNode;
+  onClick?: () => void;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  children,
+  className,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        // base styles
+        'rounded-md font-semibold transition-all',
+        // variant styles
+        variant === 'primary' && 'bg-primary text-white hover:bg-primary-light',
+        variant === 'secondary' && 'border border-primary text-primary hover:bg-primary/10',
+        variant === 'ghost' && 'text-primary hover:bg-primary/5',
+        // size styles
+        size === 'sm' && 'px-3 py-1.5 text-sm',
+        size === 'md' && 'px-5 py-2.5 text-sm',
+        size === 'lg' && 'px-6 py-3 text-base',
+        // disabled
+        disabled && 'opacity-50 cursor-not-allowed',
+        className
+      )}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/Button/index.ts
+++ b/src/components/ui/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from './Button';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,2 @@
+// Button
+export { Button } from './Button';


### PR DESCRIPTION
## Summary

- Buttonコンポーネントを実装
- 3種類のvariant（primary, secondary, ghost）
- 3種類のsize（sm, md, lg）
- disabled状態の対応
- カスタムclassName対応

## Test Plan

- [x] 13件の単体テストを追加し全てパス
- [x] 各variantのスタイル適用テスト
- [x] 各sizeのスタイル適用テスト
- [x] disabled状態のテスト
- [x] onClickイベントのテスト
- [x] 追加属性（type, className）のテスト

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)