### PR TITLE
feat(ui): Cardコンポーネント実装 (Issue #11)

### DIFF
--- a/src/components/ui/Card/Card.test.tsx
+++ b/src/components/ui/Card/Card.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Card } from './Card';
+
+describe('Card', () => {
+  describe('レンダリング', () => {
+    it('子要素を正しくレンダリングする', () => {
+      render(<Card>Card content</Card>);
+      expect(screen.getByText('Card content')).toBeInTheDocument();
+    });
+
+    it('タイトルを表示する', () => {
+      render(<Card title="Monthly Income">Content</Card>);
+      expect(screen.getByText('Monthly Income')).toBeInTheDocument();
+    });
+
+    it('タイトルがない場合は表示しない', () => {
+      render(<Card>Content only</Card>);
+      expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('スタイル', () => {
+    it('基本スタイルが適用される', () => {
+      render(<Card data-testid="card">Content</Card>);
+      const card = screen.getByTestId('card');
+      expect(card).toHaveClass('bg-surface');
+      expect(card).toHaveClass('rounded-lg');
+      expect(card).toHaveClass('shadow-md');
+      expect(card).toHaveClass('p-6');
+    });
+
+    it('カスタムclassNameを追加できる', () => {
+      render(
+        <Card className="custom-class" data-testid="card">
+          Content
+        </Card>
+      );
+      const card = screen.getByTestId('card');
+      expect(card).toHaveClass('custom-class');
+    });
+  });
+
+  describe('アクセントカラー', () => {
+    it('income アクセントカラーが適用される', () => {
+      render(
+        <Card accentColor="income" data-testid="card">
+          Content
+        </Card>
+      );
+      const card = screen.getByTestId('card');
+      expect(card).toHaveClass('border-l-4');
+      expect(card).toHaveClass('border-income');
+    });
+
+    it('expense アクセントカラーが適用される', () => {
+      render(
+        <Card accentColor="expense" data-testid="card">
+          Content
+        </Card>
+      );
+      const card = screen.getByTestId('card');
+      expect(card).toHaveClass('border-l-4');
+      expect(card).toHaveClass('border-expense');
+    });
+
+    it('primary アクセントカラーが適用される', () => {
+      render(
+        <Card accentColor="primary" data-testid="card">
+          Content
+        </Card>
+      );
+      const card = screen.getByTestId('card');
+      expect(card).toHaveClass('border-l-4');
+      expect(card).toHaveClass('border-primary');
+    });
+
+    it('アクセントカラーがない場合はボーダーなし', () => {
+      render(<Card data-testid="card">Content</Card>);
+      const card = screen.getByTestId('card');
+      expect(card).not.toHaveClass('border-l-4');
+    });
+  });
+
+  describe('ホバー効果', () => {
+    it('ホバー時のシャドウクラスが設定されている', () => {
+      render(<Card data-testid="card">Content</Card>);
+      const card = screen.getByTestId('card');
+      expect(card).toHaveClass('hover:shadow-lg');
+      expect(card).toHaveClass('transition-shadow');
+    });
+  });
+});

--- a/src/components/ui/Card/Card.tsx
+++ b/src/components/ui/Card/Card.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/utils';
+
+type CardProps = {
+  title?: string;
+  children: React.ReactNode;
+  className?: string;
+  accentColor?: 'income' | 'expense' | 'primary';
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export function Card({ title, children, className, accentColor, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'bg-surface rounded-lg shadow-md p-6',
+        'hover:shadow-lg transition-shadow',
+        accentColor === 'income' && 'border-l-4 border-income',
+        accentColor === 'expense' && 'border-l-4 border-expense',
+        accentColor === 'primary' && 'border-l-4 border-primary',
+        className
+      )}
+      {...props}
+    >
+      {title && <h3 className="text-text-secondary text-sm font-medium mb-2">{title}</h3>}
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/Card/index.ts
+++ b/src/components/ui/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card } from './Card';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,5 @@
 // Button
 export { Button } from './Button';
+
+// Card
+export { Card } from './Card';


### PR DESCRIPTION
## Summary

- Cardコンポーネントを実装
- 基本スタイル（背景、角丸、シャドウ、パディング）
- オプションのタイトル表示
- アクセントカラー（income, expense, primary）による左ボーダー
- ホバー時のシャドウ効果

## Test Plan

- [x] 10件の単体テストを追加し全てパス
- [x] 子要素の表示テスト
- [x] タイトル表示テスト
- [x] 各アクセントカラーのテスト
- [x] ホバー効果のクラス設定テスト

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)