### PR TITLE
feat(ui): Badgeコンポーネント実装 (Issue #12)

### DIFF
--- a/src/components/ui/Badge/Badge.test.tsx
+++ b/src/components/ui/Badge/Badge.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Badge } from './Badge';
+
+describe('Badge', () => {
+  describe('レンダリング', () => {
+    it('子要素を正しくレンダリングする', () => {
+      render(<Badge>食費</Badge>);
+      expect(screen.getByText('食費')).toBeInTheDocument();
+    });
+  });
+
+  describe('variant', () => {
+    it('defaultがデフォルトで適用される', () => {
+      render(<Badge data-testid="badge">Default</Badge>);
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('bg-gray-100');
+      expect(badge).toHaveClass('text-gray-800');
+    });
+
+    it('incomeスタイルが適用される', () => {
+      render(
+        <Badge variant="income" data-testid="badge">
+          Income
+        </Badge>
+      );
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('bg-income-light');
+      expect(badge).toHaveClass('text-income');
+    });
+
+    it('expenseスタイルが適用される', () => {
+      render(
+        <Badge variant="expense" data-testid="badge">
+          Expense
+        </Badge>
+      );
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('bg-expense-light');
+      expect(badge).toHaveClass('text-expense');
+    });
+
+    it('warningスタイルが適用される', () => {
+      render(
+        <Badge variant="warning" data-testid="badge">
+          Warning
+        </Badge>
+      );
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('bg-warning-light');
+      expect(badge).toHaveClass('text-warning');
+    });
+  });
+
+  describe('size', () => {
+    it('mdがデフォルトで適用される', () => {
+      render(<Badge data-testid="badge">Medium</Badge>);
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('px-2.5');
+      expect(badge).toHaveClass('py-1');
+      expect(badge).toHaveClass('text-sm');
+    });
+
+    it('smサイズが適用される', () => {
+      render(
+        <Badge size="sm" data-testid="badge">
+          Small
+        </Badge>
+      );
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('px-2');
+      expect(badge).toHaveClass('py-0.5');
+      expect(badge).toHaveClass('text-xs');
+    });
+  });
+
+  describe('スタイル', () => {
+    it('基本スタイルが適用される', () => {
+      render(<Badge data-testid="badge">Content</Badge>);
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('inline-flex');
+      expect(badge).toHaveClass('items-center');
+      expect(badge).toHaveClass('rounded-full');
+      expect(badge).toHaveClass('font-medium');
+    });
+
+    it('カスタムclassNameを追加できる', () => {
+      render(
+        <Badge className="custom-class" data-testid="badge">
+          Content
+        </Badge>
+      );
+      const badge = screen.getByTestId('badge');
+      expect(badge).toHaveClass('custom-class');
+    });
+  });
+});

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/utils';
+
+type BadgeProps = {
+  variant?: 'default' | 'income' | 'expense' | 'warning';
+  size?: 'sm' | 'md';
+  children: React.ReactNode;
+  className?: string;
+} & React.HTMLAttributes<HTMLSpanElement>;
+
+export function Badge({
+  variant = 'default',
+  size = 'md',
+  children,
+  className,
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full font-medium',
+        // variant
+        variant === 'default' && 'bg-gray-100 text-gray-800',
+        variant === 'income' && 'bg-income-light text-income',
+        variant === 'expense' && 'bg-expense-light text-expense',
+        variant === 'warning' && 'bg-warning-light text-warning',
+        // size
+        size === 'sm' && 'px-2 py-0.5 text-xs',
+        size === 'md' && 'px-2.5 py-1 text-sm',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Badge/index.ts
+++ b/src/components/ui/Badge/index.ts
@@ -1,0 +1,1 @@
+export { Badge } from './Badge';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,3 +3,6 @@ export { Button } from './Button';
 
 // Card
 export { Card } from './Card';
+
+// Badge
+export { Badge } from './Badge';


### PR DESCRIPTION
## Summary

- Badgeコンポーネントを実装
- 4種類のvariant（default, income, expense, warning）
- 2種類のsize（sm, md）

## Test Plan

- [x] 9件の単体テストを追加し全てパス

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)