### PR TITLE
feat(ui): Input, Select, SearchInputコンポーネント実装 (Issue #13)

### DIFF
--- a/src/components/ui/Input/Input.test.tsx
+++ b/src/components/ui/Input/Input.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Input } from './Input';
+import { Select } from './Select';
+import { SearchInput } from './SearchInput';
+
+describe('Input', () => {
+  describe('レンダリング', () => {
+    it('inputを正しくレンダリングする', () => {
+      render(<Input placeholder="入力してください" />);
+      expect(screen.getByPlaceholderText('入力してください')).toBeInTheDocument();
+    });
+
+    it('ラベルを表示する', () => {
+      render(<Input label="名前" />);
+      expect(screen.getByText('名前')).toBeInTheDocument();
+    });
+
+    it('エラーメッセージを表示する', () => {
+      render(<Input error="入力必須です" />);
+      expect(screen.getByText('入力必須です')).toBeInTheDocument();
+    });
+
+    it('エラー時にボーダー色が変わる', () => {
+      render(<Input error="エラー" data-testid="input" />);
+      const input = screen.getByTestId('input');
+      expect(input).toHaveClass('border-expense');
+    });
+  });
+
+  describe('インタラクション', () => {
+    it('入力が正しく反映される', async () => {
+      const user = userEvent.setup();
+      render(<Input data-testid="input" />);
+
+      const input = screen.getByTestId('input');
+      await user.type(input, 'テスト');
+
+      expect(input).toHaveValue('テスト');
+    });
+  });
+});
+
+describe('Select', () => {
+  const options = [
+    { value: '', label: '選択してください' },
+    { value: 'food', label: '食費' },
+    { value: 'transport', label: '交通費' },
+  ];
+
+  describe('レンダリング', () => {
+    it('selectを正しくレンダリングする', () => {
+      render(<Select options={options} />);
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    it('オプションを表示する', () => {
+      render(<Select options={options} />);
+      expect(screen.getByText('選択してください')).toBeInTheDocument();
+      expect(screen.getByText('食費')).toBeInTheDocument();
+      expect(screen.getByText('交通費')).toBeInTheDocument();
+    });
+
+    it('ラベルを表示する', () => {
+      render(<Select label="カテゴリ" options={options} />);
+      expect(screen.getByText('カテゴリ')).toBeInTheDocument();
+    });
+  });
+
+  describe('インタラクション', () => {
+    it('選択が正しく反映される', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(<Select options={options} onChange={handleChange} />);
+
+      const select = screen.getByRole('combobox');
+      await user.selectOptions(select, 'food');
+
+      expect(handleChange).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('SearchInput', () => {
+  describe('レンダリング', () => {
+    it('inputを正しくレンダリングする', () => {
+      render(<SearchInput value="" onChange={() => {}} />);
+      expect(screen.getByPlaceholderText('検索...')).toBeInTheDocument();
+    });
+
+    it('カスタムプレースホルダーを表示する', () => {
+      render(<SearchInput value="" onChange={() => {}} placeholder="キーワード検索" />);
+      expect(screen.getByPlaceholderText('キーワード検索')).toBeInTheDocument();
+    });
+
+    it('検索アイコンが表示される', () => {
+      render(<SearchInput value="" onChange={() => {}} />);
+      // SVGアイコンが存在することを確認
+      expect(document.querySelector('svg')).toBeInTheDocument();
+    });
+  });
+
+  describe('インタラクション', () => {
+    it('入力時にonChangeが呼ばれる', async () => {
+      const handleChange = vi.fn();
+      const user = userEvent.setup();
+      render(<SearchInput value="" onChange={handleChange} />);
+
+      const input = screen.getByPlaceholderText('検索...');
+      await user.type(input, 'test');
+
+      expect(handleChange).toHaveBeenCalledWith('t');
+      expect(handleChange).toHaveBeenCalledWith('e');
+      expect(handleChange).toHaveBeenCalledWith('s');
+      expect(handleChange).toHaveBeenCalledWith('t');
+    });
+
+    it('valueが正しく表示される', () => {
+      render(<SearchInput value="検索ワード" onChange={() => {}} />);
+      const input = screen.getByPlaceholderText('検索...');
+      expect(input).toHaveValue('検索ワード');
+    });
+  });
+});

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/utils';
+
+type InputProps = {
+  label?: string;
+  error?: string;
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+export function Input({ label, error, className, ...props }: InputProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <label className="text-sm text-text-secondary">{label}</label>}
+      <input
+        className={cn(
+          'px-3 py-2 border border-border rounded-md',
+          'focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary',
+          error && 'border-expense',
+          className
+        )}
+        {...props}
+      />
+      {error && <span className="text-sm text-expense">{error}</span>}
+    </div>
+  );
+}

--- a/src/components/ui/Input/SearchInput.tsx
+++ b/src/components/ui/Input/SearchInput.tsx
@@ -1,0 +1,32 @@
+import { Search } from 'lucide-react';
+import { cn } from '@/utils';
+
+type SearchInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+};
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = '検索...',
+  className,
+}: SearchInputProps) {
+  return (
+    <div className={cn('relative', className)}>
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-tertiary" />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={cn(
+          'pl-10 pr-4 py-2 border border-border rounded-md w-full',
+          'focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary'
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/Input/Select.tsx
+++ b/src/components/ui/Input/Select.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/utils';
+
+type SelectProps = {
+  label?: string;
+  options: { value: string; label: string }[];
+} & React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export function Select({ label, options, className, ...props }: SelectProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <label className="text-sm text-text-secondary">{label}</label>}
+      <select
+        className={cn(
+          'px-3 py-2 border border-border rounded-md',
+          'focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary',
+          className
+        )}
+        {...props}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/ui/Input/index.ts
+++ b/src/components/ui/Input/index.ts
@@ -1,0 +1,3 @@
+export { Input } from './Input';
+export { Select } from './Select';
+export { SearchInput } from './SearchInput';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,3 +6,6 @@ export { Card } from './Card';
 
 // Badge
 export { Badge } from './Badge';
+
+// Input
+export { Input, Select, SearchInput } from './Input';


### PR DESCRIPTION
## Summary

- Input: 基本入力フィールド（ラベル、エラー表示対応）
- Select: ドロップダウン選択
- SearchInput: 検索アイコン付き入力フィールド

## Test Plan

- [x] 14件の単体テストを追加し全てパス

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)