### PR TITLE
feat(ui): Tableコンポーネント群実装 (Issue #14)

### DIFF
--- a/src/components/ui/Table/Table.test.tsx
+++ b/src/components/ui/Table/Table.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Table, TableHeader, TableRow, TableCell } from './index';
+
+describe('Table', () => {
+  describe('レンダリング', () => {
+    it('tableを正しくレンダリングする', () => {
+      render(
+        <Table>
+          <tbody>
+            <tr>
+              <td>Content</td>
+            </tr>
+          </tbody>
+        </Table>
+      );
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    it('カスタムclassNameを追加できる', () => {
+      render(
+        <Table className="custom-class">
+          <tbody>
+            <tr>
+              <td>Content</td>
+            </tr>
+          </tbody>
+        </Table>
+      );
+      expect(screen.getByRole('table')).toHaveClass('custom-class');
+    });
+  });
+});
+
+describe('TableHeader', () => {
+  describe('レンダリング', () => {
+    it('theadを正しくレンダリングする', () => {
+      render(
+        <table>
+          <TableHeader>
+            <TableCell header>Header</TableCell>
+          </TableHeader>
+        </table>
+      );
+      expect(screen.getByRole('rowgroup')).toBeInTheDocument();
+    });
+
+    it('ヘッダースタイルが適用される', () => {
+      render(
+        <table>
+          <TableHeader>
+            <TableCell header>Header</TableCell>
+          </TableHeader>
+        </table>
+      );
+      expect(screen.getByRole('rowgroup')).toHaveClass('bg-surface-hover');
+    });
+  });
+});
+
+describe('TableRow', () => {
+  describe('レンダリング', () => {
+    it('trを正しくレンダリングする', () => {
+      render(
+        <table>
+          <tbody>
+            <TableRow>
+              <td>Cell</td>
+            </TableRow>
+          </tbody>
+        </table>
+      );
+      expect(screen.getByRole('row')).toBeInTheDocument();
+    });
+
+    it('ホバースタイルが適用される', () => {
+      render(
+        <table>
+          <tbody>
+            <TableRow>
+              <td>Cell</td>
+            </TableRow>
+          </tbody>
+        </table>
+      );
+      expect(screen.getByRole('row')).toHaveClass('hover:bg-background');
+    });
+
+    it('クリック可能な行にカーソルスタイルが適用される', () => {
+      render(
+        <table>
+          <tbody>
+            <TableRow onClick={() => {}}>
+              <td>Cell</td>
+            </TableRow>
+          </tbody>
+        </table>
+      );
+      expect(screen.getByRole('row')).toHaveClass('cursor-pointer');
+    });
+  });
+
+  describe('インタラクション', () => {
+    it('クリック時にonClickが呼ばれる', async () => {
+      const handleClick = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <table>
+          <tbody>
+            <TableRow onClick={handleClick}>
+              <td>Cell</td>
+            </TableRow>
+          </tbody>
+        </table>
+      );
+
+      await user.click(screen.getByRole('row'));
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('TableCell', () => {
+  describe('レンダリング', () => {
+    it('tdを正しくレンダリングする', () => {
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <TableCell>Cell</TableCell>
+            </tr>
+          </tbody>
+        </table>
+      );
+      expect(screen.getByRole('cell')).toBeInTheDocument();
+      expect(screen.getByText('Cell')).toBeInTheDocument();
+    });
+
+    it('thをレンダリングできる', () => {
+      render(
+        <table>
+          <thead>
+            <tr>
+              <TableCell header>Header</TableCell>
+            </tr>
+          </thead>
+        </table>
+      );
+      expect(screen.getByRole('columnheader')).toBeInTheDocument();
+    });
+  });
+
+  describe('align', () => {
+    it('左揃えがデフォルト', () => {
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <TableCell>Cell</TableCell>
+            </tr>
+          </tbody>
+        </table>
+      );
+      expect(screen.getByRole('cell')).toHaveClass('text-left');
+    });
+
+    it('中央揃えが適用される', () => {
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <TableCell align="center">Cell</TableCell>
+            </tr>
+          </tbody>
+        </table>
+      );
+      expect(screen.getByRole('cell')).toHaveClass('text-center');
+    });
+
+    it('右揃えが適用される', () => {
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <TableCell align="right">Cell</TableCell>
+            </tr>
+          </tbody>
+        </table>
+      );
+      expect(screen.getByRole('cell')).toHaveClass('text-right');
+    });
+  });
+
+  describe('ヘッダースタイル', () => {
+    it('ヘッダーセルにスタイルが適用される', () => {
+      render(
+        <table>
+          <thead>
+            <tr>
+              <TableCell header>Header</TableCell>
+            </tr>
+          </thead>
+        </table>
+      );
+      const cell = screen.getByRole('columnheader');
+      expect(cell).toHaveClass('text-text-secondary');
+      expect(cell).toHaveClass('text-xs');
+      expect(cell).toHaveClass('font-semibold');
+      expect(cell).toHaveClass('uppercase');
+    });
+  });
+});

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/utils';
+
+type TableProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function Table({ children, className }: TableProps) {
+  return (
+    <div className="overflow-x-auto">
+      <table className={cn('w-full', className)}>{children}</table>
+    </div>
+  );
+}

--- a/src/components/ui/Table/TableCell.tsx
+++ b/src/components/ui/Table/TableCell.tsx
@@ -1,0 +1,25 @@
+import { cn } from '@/utils';
+
+type TableCellProps = {
+  children: React.ReactNode;
+  header?: boolean;
+  align?: 'left' | 'center' | 'right';
+};
+
+export function TableCell({ children, header = false, align = 'left' }: TableCellProps) {
+  const Component = header ? 'th' : 'td';
+  return (
+    <Component
+      className={cn(
+        'px-4 py-3',
+        header && 'text-text-secondary text-xs font-semibold uppercase tracking-wider',
+        !header && 'text-sm',
+        align === 'left' && 'text-left',
+        align === 'center' && 'text-center',
+        align === 'right' && 'text-right'
+      )}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/src/components/ui/Table/TableHeader.tsx
+++ b/src/components/ui/Table/TableHeader.tsx
@@ -1,0 +1,11 @@
+type TableHeaderProps = {
+  children: React.ReactNode;
+};
+
+export function TableHeader({ children }: TableHeaderProps) {
+  return (
+    <thead className="bg-surface-hover">
+      <tr>{children}</tr>
+    </thead>
+  );
+}

--- a/src/components/ui/Table/TableRow.tsx
+++ b/src/components/ui/Table/TableRow.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/utils';
+
+type TableRowProps = {
+  children: React.ReactNode;
+  onClick?: () => void;
+};
+
+export function TableRow({ children, onClick }: TableRowProps) {
+  return (
+    <tr
+      className={cn(
+        'border-b border-border',
+        'hover:bg-background transition-colors',
+        onClick && 'cursor-pointer'
+      )}
+      onClick={onClick}
+    >
+      {children}
+    </tr>
+  );
+}

--- a/src/components/ui/Table/index.ts
+++ b/src/components/ui/Table/index.ts
@@ -1,0 +1,4 @@
+export { Table } from './Table';
+export { TableHeader } from './TableHeader';
+export { TableRow } from './TableRow';
+export { TableCell } from './TableCell';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,3 +9,6 @@ export { Badge } from './Badge';
 
 // Input
 export { Input, Select, SearchInput } from './Input';
+
+// Table
+export { Table, TableHeader, TableRow, TableCell } from './Table';


### PR DESCRIPTION
## Summary

- Table: テーブルコンテナ
- TableHeader: ヘッダー行
- TableRow: データ行（クリック対応、ホバーハイライト）
- TableCell: セル（th/td切り替え、align対応）

## Test Plan

- [x] 14件の単体テストを追加し全てパス

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)