### PR TITLE
feat(ui): Icon/CategoryIconコンポーネントを実装 #15

### DIFF
--- a/src/components/ui/Icon/CategoryIcon.tsx
+++ b/src/components/ui/Icon/CategoryIcon.tsx
@@ -1,0 +1,22 @@
+import { Icon, type IconSize, type IconProps } from './Icon';
+import { getCategoryColor, getCategoryIcon } from '@/constants';
+
+export type CategoryIconProps = {
+  /** カテゴリ名 */
+  category: string;
+  /** サイズ */
+  size?: IconSize;
+  /** カスタムクラス */
+  className?: string | undefined;
+} & Omit<IconProps, 'name' | 'color' | 'size' | 'className'>;
+
+/**
+ * カテゴリ別アイコンコンポーネント
+ * カテゴリに応じた色とアイコンを自動的に表示する
+ */
+export function CategoryIcon({ category, size = 'md', className, ...props }: CategoryIconProps) {
+  const iconName = getCategoryIcon(category);
+  const color = getCategoryColor(category);
+
+  return <Icon name={iconName} size={size} color={color} className={className} {...props} />;
+}

--- a/src/components/ui/Icon/Icon.test.tsx
+++ b/src/components/ui/Icon/Icon.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Icon, CategoryIcon } from './index';
+
+describe('Icon', () => {
+  describe('レンダリング', () => {
+    it('アイコンを正しくレンダリングする', () => {
+      render(<Icon name="camera" data-testid="icon" />);
+      expect(screen.getByTestId('icon')).toBeInTheDocument();
+    });
+
+    it('SVG要素としてレンダリングされる', () => {
+      render(<Icon name="heart" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon.tagName.toLowerCase()).toBe('svg');
+    });
+  });
+
+  describe('サイズ', () => {
+    it('smサイズで16pxになる', () => {
+      render(<Icon name="camera" size="sm" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveAttribute('width', '16');
+      expect(icon).toHaveAttribute('height', '16');
+    });
+
+    it('mdサイズで20pxになる', () => {
+      render(<Icon name="camera" size="md" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveAttribute('width', '20');
+      expect(icon).toHaveAttribute('height', '20');
+    });
+
+    it('lgサイズで24pxになる', () => {
+      render(<Icon name="camera" size="lg" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveAttribute('width', '24');
+      expect(icon).toHaveAttribute('height', '24');
+    });
+
+    it('xlサイズで32pxになる', () => {
+      render(<Icon name="camera" size="xl" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveAttribute('width', '32');
+      expect(icon).toHaveAttribute('height', '32');
+    });
+
+    it('デフォルトサイズはmd(20px)になる', () => {
+      render(<Icon name="camera" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveAttribute('width', '20');
+      expect(icon).toHaveAttribute('height', '20');
+    });
+  });
+
+  describe('カラー', () => {
+    it('color propsで色を指定できる', () => {
+      render(<Icon name="camera" color="#FF0000" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      // Lucide iconsはcolorをstroke属性として適用する
+      expect(icon).toHaveAttribute('stroke', '#FF0000');
+    });
+  });
+
+  describe('カスタムクラス', () => {
+    it('classNameを追加できる', () => {
+      render(<Icon name="camera" className="custom-class" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveClass('custom-class');
+    });
+  });
+
+  describe('存在しないアイコン', () => {
+    it('存在しないアイコン名の場合はフォールバックアイコンを表示', () => {
+      render(<Icon name="nonexistent-icon" data-testid="icon" />);
+      // more-horizontal (MoreHorizontal) がフォールバックとして表示される
+      expect(screen.getByTestId('icon')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('CategoryIcon', () => {
+  describe('レンダリング', () => {
+    it('カテゴリに対応するアイコンを表示する', () => {
+      render(<CategoryIcon category="食費" data-testid="icon" />);
+      expect(screen.getByTestId('icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('色', () => {
+    it('カテゴリに対応する色が適用される', () => {
+      render(<CategoryIcon category="食費" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      // 食費の色は #F59E0B (stroke属性として適用される)
+      expect(icon).toHaveAttribute('stroke', '#F59E0B');
+    });
+
+    it('交通費カテゴリで青色が適用される', () => {
+      render(<CategoryIcon category="交通費" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      // 交通費の色は #3B82F6 (stroke属性として適用される)
+      expect(icon).toHaveAttribute('stroke', '#3B82F6');
+    });
+
+    it('未知のカテゴリではデフォルト色が適用される', () => {
+      render(<CategoryIcon category="不明なカテゴリ" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      // その他の色は #6B7280 (stroke属性として適用される)
+      expect(icon).toHaveAttribute('stroke', '#6B7280');
+    });
+  });
+
+  describe('サイズ', () => {
+    it('sizeプロップでサイズを指定できる', () => {
+      render(<CategoryIcon category="食費" size="lg" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveAttribute('width', '24');
+      expect(icon).toHaveAttribute('height', '24');
+    });
+
+    it('デフォルトサイズはmd', () => {
+      render(<CategoryIcon category="食費" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveAttribute('width', '20');
+      expect(icon).toHaveAttribute('height', '20');
+    });
+  });
+
+  describe('カスタムクラス', () => {
+    it('classNameを追加できる', () => {
+      render(<CategoryIcon category="食費" className="custom-class" data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveClass('custom-class');
+    });
+  });
+
+  describe('各カテゴリ', () => {
+    const categories = [
+      '食費',
+      '日用品',
+      '交通費',
+      '通信費',
+      '教養・教育',
+      '健康・医療',
+      '衣服・美容',
+      '趣味・娯楽',
+      '水道・光熱費',
+      '交際費',
+      'その他',
+      '収入',
+    ];
+
+    categories.forEach((category) => {
+      it(`${category}のアイコンが表示される`, () => {
+        render(<CategoryIcon category={category} data-testid="icon" />);
+        expect(screen.getByTestId('icon')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/ui/Icon/Icon.tsx
+++ b/src/components/ui/Icon/Icon.tsx
@@ -1,0 +1,69 @@
+import {
+  Utensils,
+  ShoppingBag,
+  Train,
+  Smartphone,
+  BookOpen,
+  HeartPulse,
+  Shirt,
+  Gamepad2,
+  Zap,
+  Users,
+  MoreHorizontal,
+  ArrowUpCircle,
+  Camera,
+  Heart,
+  type LucideIcon,
+  type LucideProps,
+} from 'lucide-react';
+import { cn } from '@/utils';
+
+/** アイコン名からLucideIconへのマッピング */
+const ICON_MAP: Record<string, LucideIcon> = {
+  utensils: Utensils,
+  'shopping-bag': ShoppingBag,
+  train: Train,
+  smartphone: Smartphone,
+  'book-open': BookOpen,
+  'heart-pulse': HeartPulse,
+  shirt: Shirt,
+  'gamepad-2': Gamepad2,
+  zap: Zap,
+  users: Users,
+  'more-horizontal': MoreHorizontal,
+  'arrow-up-circle': ArrowUpCircle,
+  camera: Camera,
+  heart: Heart,
+};
+
+/** サイズマッピング */
+const SIZE_MAP = {
+  sm: 16,
+  md: 20,
+  lg: 24,
+  xl: 32,
+} as const;
+
+export type IconSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export type IconProps = {
+  /** アイコン名 (kebab-case) */
+  name: string;
+  /** サイズ */
+  size?: IconSize;
+  /** 色 */
+  color?: string;
+  /** カスタムクラス */
+  className?: string | undefined;
+} & Omit<LucideProps, 'size' | 'className'>;
+
+/**
+ * Lucide Iconsラッパーコンポーネント
+ * アイコン名を文字列で指定してアイコンを表示する
+ */
+export function Icon({ name, size = 'md', color, className, ...props }: IconProps) {
+  const IconComponent = ICON_MAP[name] ?? MoreHorizontal;
+  const pixelSize = SIZE_MAP[size];
+
+  return <IconComponent size={pixelSize} color={color} className={cn(className)} {...props} />;
+}

--- a/src/components/ui/Icon/index.ts
+++ b/src/components/ui/Icon/index.ts
@@ -1,0 +1,4 @@
+export { Icon } from './Icon';
+export type { IconProps, IconSize } from './Icon';
+export { CategoryIcon } from './CategoryIcon';
+export type { CategoryIconProps } from './CategoryIcon';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -12,3 +12,6 @@ export { Input, Select, SearchInput } from './Input';
 
 // Table
 export { Table, TableHeader, TableRow, TableCell } from './Table';
+
+// Icon
+export { Icon, CategoryIcon } from './Icon';


### PR DESCRIPTION
## Summary
- Iconコンポーネント: Lucide Iconsのラッパー (文字列でアイコン名指定、4サイズ対応)
- CategoryIconコンポーネント: カテゴリに応じた色とアイコンを自動表示
- 29テスト追加

## Test plan
- [x] `npm run test` - 262テスト全てパス
- [x] `npm run lint` - エラーなし
- [x] 4種類のサイズ (sm/md/lg/xl) が正しく動作
- [x] カテゴリに応じた色とアイコンが表示される
- [x] 存在しないアイコン名でフォールバックが動作

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)