### PR TITLE
feat(ui): Amountコンポーネントを実装 #16

### DIFF
--- a/src/components/ui/Amount/Amount.test.tsx
+++ b/src/components/ui/Amount/Amount.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Amount } from './index';
+
+describe('Amount', () => {
+  describe('表示形式', () => {
+    it('正の金額を符号付きで表示する', () => {
+      render(<Amount value={1234} />);
+      expect(screen.getByText('+¥1,234')).toBeInTheDocument();
+    });
+
+    it('負の金額を符号付きで表示する', () => {
+      render(<Amount value={-5678} />);
+      expect(screen.getByText('-¥5,678')).toBeInTheDocument();
+    });
+
+    it('ゼロを符号なしで表示する', () => {
+      render(<Amount value={0} />);
+      expect(screen.getByText('¥0')).toBeInTheDocument();
+    });
+
+    it('3桁区切りカンマで表示する', () => {
+      render(<Amount value={1234567} />);
+      expect(screen.getByText('+¥1,234,567')).toBeInTheDocument();
+    });
+  });
+
+  describe('符号なし表示', () => {
+    it('showSign=falseで符号なしの金額を表示する', () => {
+      render(<Amount value={1000} showSign={false} />);
+      expect(screen.getByText('¥1,000')).toBeInTheDocument();
+    });
+
+    it('showSign=falseで負の金額も符号なしで表示する', () => {
+      render(<Amount value={-500} showSign={false} />);
+      expect(screen.getByText('¥500')).toBeInTheDocument();
+    });
+  });
+
+  describe('色分け', () => {
+    it('正の金額を緑色（text-income）で表示する', () => {
+      render(<Amount value={1000} />);
+      expect(screen.getByText('+¥1,000')).toHaveClass('text-income');
+    });
+
+    it('負の金額を赤色（text-expense）で表示する', () => {
+      render(<Amount value={-500} />);
+      expect(screen.getByText('-¥500')).toHaveClass('text-expense');
+    });
+
+    it('ゼロを通常色で表示する', () => {
+      render(<Amount value={0} />);
+      expect(screen.getByText('¥0')).toHaveClass('text-text-primary');
+    });
+  });
+
+  describe('サイズ', () => {
+    it('smサイズで小さいフォントを適用する', () => {
+      render(<Amount value={100} size="sm" />);
+      expect(screen.getByText('+¥100')).toHaveClass('text-sm');
+    });
+
+    it('mdサイズで通常フォントを適用する', () => {
+      render(<Amount value={100} size="md" />);
+      expect(screen.getByText('+¥100')).toHaveClass('text-base');
+    });
+
+    it('lgサイズで大きいフォントを適用する', () => {
+      render(<Amount value={100} size="lg" />);
+      const element = screen.getByText('+¥100');
+      expect(element).toHaveClass('text-2xl');
+      expect(element).toHaveClass('font-bold');
+    });
+
+    it('デフォルトサイズはmd', () => {
+      render(<Amount value={100} />);
+      expect(screen.getByText('+¥100')).toHaveClass('text-base');
+    });
+  });
+
+  describe('フォント', () => {
+    it('等幅フォントが適用される', () => {
+      render(<Amount value={1000} />);
+      const element = screen.getByText('+¥1,000');
+      expect(element).toHaveClass('font-mono');
+      expect(element).toHaveClass('tabular-nums');
+    });
+  });
+
+  describe('カスタムクラス', () => {
+    it('classNameを追加できる', () => {
+      render(<Amount value={1000} className="custom-class" />);
+      expect(screen.getByText('+¥1,000')).toHaveClass('custom-class');
+    });
+  });
+});

--- a/src/components/ui/Amount/Amount.tsx
+++ b/src/components/ui/Amount/Amount.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/utils';
+import { formatCurrency, formatAmount } from '@/utils/formatters';
+
+type AmountProps = {
+  /** 金額（正: 収入、負: 支出） */
+  value: number;
+  /** サイズ */
+  size?: 'sm' | 'md' | 'lg';
+  /** 符号を表示するか（デフォルト: true） */
+  showSign?: boolean;
+  /** カスタムクラス */
+  className?: string;
+};
+
+const sizeClasses = {
+  sm: 'text-sm',
+  md: 'text-base',
+  lg: 'text-2xl font-bold',
+} as const;
+
+/**
+ * 金額表示コンポーネント
+ * 収入は緑、支出は赤で表示する
+ */
+export function Amount({ value, size = 'md', showSign = true, className }: AmountProps) {
+  const formatted = showSign ? formatCurrency(value) : formatAmount(value);
+  const colorClass = value > 0 ? 'text-income' : value < 0 ? 'text-expense' : 'text-text-primary';
+
+  return (
+    <span className={cn('font-mono tabular-nums', sizeClasses[size], colorClass, className)}>
+      {formatted}
+    </span>
+  );
+}

--- a/src/components/ui/Amount/index.ts
+++ b/src/components/ui/Amount/index.ts
@@ -1,0 +1,1 @@
+export { Amount } from './Amount';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,3 +15,6 @@ export { Table, TableHeader, TableRow, TableCell } from './Table';
 
 // Icon
 export { Icon, CategoryIcon } from './Icon';
+
+// Amount
+export { Amount } from './Amount';


### PR DESCRIPTION
## Summary
- 金額表示コンポーネント（収入=緑、支出=赤）
- 3種類のサイズ (sm/md/lg)、符号表示オプション
- 等幅フォント対応（font-mono tabular-nums）
- 15テスト追加

## Test plan
- [x] `npm run test` - 277テスト全てパス
- [x] 正の金額が緑色で表示される
- [x] 負の金額が赤色で表示される
- [x] ゼロが通常色で表示される
- [x] 3桁区切りカンマが表示される

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)