### PR TITLE
feat(ui): TrendIndicatorコンポーネントを実装 #17

### DIFF
--- a/src/components/ui/Trend/TrendIndicator.test.tsx
+++ b/src/components/ui/Trend/TrendIndicator.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TrendIndicator } from './index';
+
+describe('TrendIndicator', () => {
+  describe('表示形式', () => {
+    it('正の変化率をパーセントで表示する', () => {
+      render(<TrendIndicator value={0.052} data-testid="trend" />);
+      expect(screen.getByText('5.2%')).toBeInTheDocument();
+    });
+
+    it('負の変化率をパーセントで表示する', () => {
+      render(<TrendIndicator value={-0.123} data-testid="trend" />);
+      expect(screen.getByText('12.3%')).toBeInTheDocument();
+    });
+
+    it('ゼロをパーセントで表示する', () => {
+      render(<TrendIndicator value={0} data-testid="trend" />);
+      expect(screen.getByText('0.0%')).toBeInTheDocument();
+    });
+  });
+
+  describe('アイコン', () => {
+    it('正の変化率で上向きアイコンが表示される', () => {
+      const { container } = render(<TrendIndicator value={0.1} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+    });
+
+    it('負の変化率で下向きアイコンが表示される', () => {
+      const { container } = render(<TrendIndicator value={-0.1} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+    });
+
+    it('ゼロで横線アイコンが表示される', () => {
+      const { container } = render(<TrendIndicator value={0} />);
+      const svg = container.querySelector('svg');
+      expect(svg).toBeInTheDocument();
+    });
+  });
+
+  describe('色分け（positiveIsGood=true: 増加が良い）', () => {
+    it('正の変化率を緑色で表示する', () => {
+      render(<TrendIndicator value={0.1} positiveIsGood={true} data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-income');
+    });
+
+    it('負の変化率を赤色で表示する', () => {
+      render(<TrendIndicator value={-0.1} positiveIsGood={true} data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-expense');
+    });
+
+    it('ゼロをグレーで表示する', () => {
+      render(<TrendIndicator value={0} data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-text-secondary');
+    });
+  });
+
+  describe('色分け（positiveIsGood=false: 増加が悪い、支出など）', () => {
+    it('正の変化率を赤色で表示する', () => {
+      render(<TrendIndicator value={0.1} positiveIsGood={false} data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-expense');
+    });
+
+    it('負の変化率を緑色で表示する', () => {
+      render(<TrendIndicator value={-0.1} positiveIsGood={false} data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-income');
+    });
+  });
+
+  describe('サイズ', () => {
+    it('smサイズで小さいフォントを適用する', () => {
+      render(<TrendIndicator value={0.1} size="sm" data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-xs');
+    });
+
+    it('mdサイズで通常フォントを適用する', () => {
+      render(<TrendIndicator value={0.1} size="md" data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-sm');
+    });
+
+    it('デフォルトサイズはmd', () => {
+      render(<TrendIndicator value={0.1} data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('text-sm');
+    });
+  });
+
+  describe('smサイズのアイコン', () => {
+    it('smサイズで12pxのアイコンが表示される', () => {
+      const { container } = render(<TrendIndicator value={0.1} size="sm" />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '12');
+      expect(svg).toHaveAttribute('height', '12');
+    });
+
+    it('mdサイズで16pxのアイコンが表示される', () => {
+      const { container } = render(<TrendIndicator value={0.1} size="md" />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('width', '16');
+      expect(svg).toHaveAttribute('height', '16');
+    });
+  });
+
+  describe('カスタムクラス', () => {
+    it('classNameを追加できる', () => {
+      render(<TrendIndicator value={0.1} className="custom-class" data-testid="trend" />);
+      expect(screen.getByTestId('trend')).toHaveClass('custom-class');
+    });
+  });
+});

--- a/src/components/ui/Trend/TrendIndicator.tsx
+++ b/src/components/ui/Trend/TrendIndicator.tsx
@@ -1,0 +1,51 @@
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { cn } from '@/utils';
+import { formatPercentage } from '@/utils/formatters';
+
+type TrendIndicatorProps = {
+  /** 変化率 (0.05 = +5%) */
+  value: number;
+  /** サイズ */
+  size?: 'sm' | 'md';
+  /** true: 増加が良い（収入）, false: 増加が悪い（支出） */
+  positiveIsGood?: boolean;
+  /** カスタムクラス */
+  className?: string;
+} & React.HTMLAttributes<HTMLSpanElement>;
+
+/**
+ * 前月比の増減を表示するインジケーターコンポーネント
+ */
+export function TrendIndicator({
+  value,
+  size = 'md',
+  positiveIsGood = true,
+  className,
+  ...props
+}: TrendIndicatorProps) {
+  const isPositive = value > 0;
+  const isNeutral = value === 0;
+
+  // 増加が良いか悪いかで色を決定
+  const isGood = positiveIsGood ? isPositive : !isPositive && !isNeutral;
+  const colorClass = isNeutral ? 'text-text-secondary' : isGood ? 'text-income' : 'text-expense';
+
+  const Icon = isNeutral ? Minus : isPositive ? TrendingUp : TrendingDown;
+  const iconSize = size === 'sm' ? 12 : 16;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1',
+        size === 'sm' && 'text-xs',
+        size === 'md' && 'text-sm',
+        colorClass,
+        className
+      )}
+      {...props}
+    >
+      <Icon size={iconSize} />
+      {formatPercentage(Math.abs(value))}
+    </span>
+  );
+}

--- a/src/components/ui/Trend/index.ts
+++ b/src/components/ui/Trend/index.ts
@@ -1,0 +1,1 @@
+export { TrendIndicator } from './TrendIndicator';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -18,3 +18,6 @@ export { Icon, CategoryIcon } from './Icon';
 
 // Amount
 export { Amount } from './Amount';
+
+// Trend
+export { TrendIndicator } from './Trend';


### PR DESCRIPTION
## Summary
- 前月比増減インジケーターコンポーネント
- positiveIsGoodフラグで色分けを制御（収入/支出向け）
- 2種類のサイズ (sm/md)
- 17テスト追加

## Test plan
- [x] `npm run test` - 294テスト全てパス
- [x] 正の変化率で上向き矢印が表示される
- [x] 負の変化率で下向き矢印が表示される
- [x] positiveIsGoodで色が切り替わる
- [x] パーセンテージが正しくフォーマットされる

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)