### PR TITLE
feat(ui): Skeletonコンポーネントを実装 #18

### DIFF
--- a/src/components/ui/Skeleton/Skeleton.test.tsx
+++ b/src/components/ui/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Skeleton, SkeletonCard, SkeletonTable } from './index';
+
+describe('Skeleton', () => {
+  describe('レンダリング', () => {
+    it('スケルトンを正しくレンダリングする', () => {
+      render(<Skeleton data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    });
+
+    it('div要素としてレンダリングされる', () => {
+      render(<Skeleton data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton').tagName.toLowerCase()).toBe('div');
+    });
+  });
+
+  describe('アニメーション', () => {
+    it('animate-pulseクラスが適用される', () => {
+      render(<Skeleton data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveClass('animate-pulse');
+    });
+
+    it('bg-gray-200クラスが適用される', () => {
+      render(<Skeleton data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveClass('bg-gray-200');
+    });
+  });
+
+  describe('variant', () => {
+    it('textバリアントでh-4とroundedが適用される', () => {
+      render(<Skeleton variant="text" data-testid="skeleton" />);
+      const el = screen.getByTestId('skeleton');
+      expect(el).toHaveClass('h-4');
+      expect(el).toHaveClass('rounded');
+    });
+
+    it('circularバリアントでrounded-fullが適用される', () => {
+      render(<Skeleton variant="circular" data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveClass('rounded-full');
+    });
+
+    it('rectangularバリアントでrounded-lgが適用される', () => {
+      render(<Skeleton variant="rectangular" data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveClass('rounded-lg');
+    });
+
+    it('デフォルトはtextバリアント', () => {
+      render(<Skeleton data-testid="skeleton" />);
+      const el = screen.getByTestId('skeleton');
+      expect(el).toHaveClass('h-4');
+      expect(el).toHaveClass('rounded');
+    });
+  });
+
+  describe('サイズ', () => {
+    it('widthを数値で指定できる', () => {
+      render(<Skeleton width={100} data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveStyle({ width: '100px' });
+    });
+
+    it('widthを文字列で指定できる', () => {
+      render(<Skeleton width="50%" data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveStyle({ width: '50%' });
+    });
+
+    it('heightを数値で指定できる', () => {
+      render(<Skeleton height={32} data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveStyle({ height: '32px' });
+    });
+
+    it('heightを文字列で指定できる', () => {
+      render(<Skeleton height="2rem" data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveStyle({ height: '2rem' });
+    });
+  });
+
+  describe('カスタムクラス', () => {
+    it('classNameを追加できる', () => {
+      render(<Skeleton className="custom-class" data-testid="skeleton" />);
+      expect(screen.getByTestId('skeleton')).toHaveClass('custom-class');
+    });
+  });
+});
+
+describe('SkeletonCard', () => {
+  it('カードスケルトンをレンダリングする', () => {
+    const { container } = render(<SkeletonCard />);
+    expect(container.querySelector('.bg-surface')).toBeInTheDocument();
+    expect(container.querySelector('.shadow-md')).toBeInTheDocument();
+  });
+
+  it('複数のSkeletonを含む', () => {
+    const { container } = render(<SkeletonCard />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SkeletonTable', () => {
+  it('デフォルトで5行のスケルトンをレンダリングする', () => {
+    const { container } = render(<SkeletonTable />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBe(5);
+  });
+
+  it('rowsプロップで行数を指定できる', () => {
+    const { container } = render(<SkeletonTable rows={3} />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBe(3);
+  });
+
+  it('rectangularバリアントのスケルトンが含まれる', () => {
+    const { container } = render(<SkeletonTable rows={1} />);
+    const skeleton = container.querySelector('.rounded-lg');
+    expect(skeleton).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Skeleton/Skeleton.tsx
+++ b/src/components/ui/Skeleton/Skeleton.tsx
@@ -1,0 +1,68 @@
+import { cn } from '@/utils';
+
+type SkeletonProps = {
+  /** カスタムクラス */
+  className?: string;
+  /** スケルトンの形状 */
+  variant?: 'text' | 'circular' | 'rectangular';
+  /** 幅 */
+  width?: string | number;
+  /** 高さ */
+  height?: string | number;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+/**
+ * ローディング中のスケルトン表示コンポーネント
+ */
+export function Skeleton({
+  className,
+  variant = 'text',
+  width,
+  height,
+  style,
+  ...props
+}: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse bg-gray-200',
+        variant === 'text' && 'h-4 rounded',
+        variant === 'circular' && 'rounded-full',
+        variant === 'rectangular' && 'rounded-lg',
+        className
+      )}
+      style={{
+        width: typeof width === 'number' ? `${width}px` : width,
+        height: typeof height === 'number' ? `${height}px` : height,
+        ...style,
+      }}
+      {...props}
+    />
+  );
+}
+
+/**
+ * カード用のスケルトンプリセット
+ */
+export function SkeletonCard() {
+  return (
+    <div className="bg-surface rounded-lg shadow-md p-6 space-y-4">
+      <Skeleton variant="text" width="40%" />
+      <Skeleton variant="text" width="60%" height={32} />
+      <Skeleton variant="text" width="30%" />
+    </div>
+  );
+}
+
+/**
+ * テーブル用のスケルトンプリセット
+ */
+export function SkeletonTable({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} variant="rectangular" height={48} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/Skeleton/index.ts
+++ b/src/components/ui/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export { Skeleton, SkeletonCard, SkeletonTable } from './Skeleton';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -21,3 +21,6 @@ export { Amount } from './Amount';
 
 // Trend
 export { TrendIndicator } from './Trend';
+
+// Skeleton
+export { Skeleton, SkeletonCard, SkeletonTable } from './Skeleton';


### PR DESCRIPTION
## Summary
- ローディング中のスケルトン表示コンポーネント
- 3種類のvariant (text/circular/rectangular)
- SkeletonCard/SkeletonTableプリセット
- 18テスト追加

## Test plan
- [x] `npm run test` - 312テスト全てパス
- [x] animate-pulseアニメーションが適用される
- [x] 3種類のvariantが正しく動作
- [x] width/heightが正しく指定できる

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)