### PR TITLE
feat(layout): Headerコンポーネントを実装 #19

### DIFF
--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Header } from './index';
+
+describe('Header', () => {
+  describe('レンダリング', () => {
+    it('header要素としてレンダリングされる', () => {
+      render(<Header />);
+      expect(screen.getByRole('banner')).toBeInTheDocument();
+    });
+
+    it('デフォルトタイトルが表示される', () => {
+      render(<Header />);
+      expect(screen.getByText('家計簿ダッシュボード')).toBeInTheDocument();
+    });
+
+    it('カスタムタイトルを表示できる', () => {
+      render(<Header title="テストタイトル" />);
+      expect(screen.getByText('テストタイトル')).toBeInTheDocument();
+    });
+  });
+
+  describe('サブタイトル', () => {
+    it('サブタイトルが指定されていない場合は表示されない', () => {
+      const { container } = render(<Header />);
+      const paragraphs = container.querySelectorAll('p');
+      expect(paragraphs.length).toBe(0);
+    });
+
+    it('サブタイトルが指定されている場合は表示される', () => {
+      render(<Header subtitle="2025年12月" />);
+      expect(screen.getByText('2025年12月')).toBeInTheDocument();
+    });
+  });
+
+  describe('スタイル', () => {
+    it('背景色がprimaryになる', () => {
+      render(<Header />);
+      expect(screen.getByRole('banner')).toHaveClass('bg-primary');
+    });
+
+    it('テキストが白になる', () => {
+      render(<Header />);
+      expect(screen.getByRole('banner')).toHaveClass('text-white');
+    });
+
+    it('タイトルが大きいフォントになる', () => {
+      render(<Header />);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveClass('text-2xl');
+    });
+
+    it('タイトルが太字になる', () => {
+      render(<Header />);
+      expect(screen.getByRole('heading', { level: 1 })).toHaveClass('font-bold');
+    });
+  });
+});

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,0 +1,20 @@
+type HeaderProps = {
+  /** ページタイトル */
+  title?: string;
+  /** サブタイトル（オプション） */
+  subtitle?: string;
+};
+
+/**
+ * ページヘッダーコンポーネント
+ */
+export function Header({ title = '家計簿ダッシュボード', subtitle }: HeaderProps) {
+  return (
+    <header className="bg-primary text-white px-6 py-4">
+      <div className="max-w-7xl mx-auto">
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {subtitle && <p className="text-primary-light text-sm mt-1">{subtitle}</p>}
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/Header/index.ts
+++ b/src/components/layout/Header/index.ts
@@ -1,0 +1,1 @@
+export { Header } from './Header';

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,2 @@
+// Header
+export { Header } from './Header';


### PR DESCRIPTION
## Summary
- ページヘッダーコンポーネント
- タイトル・サブタイトル表示
- プライマリカラー背景
- 9テスト追加

## Test plan
- [x] `npm run test` - 321テスト全てパス
- [x] デフォルトタイトルが表示される
- [x] サブタイトルがオプションで表示される

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)