### PR TITLE
feat(layout): DashboardGridコンポーネント実装 #20

### DIFF
--- a/src/components/layout/DashboardGrid/DashboardGrid.test.tsx
+++ b/src/components/layout/DashboardGrid/DashboardGrid.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DashboardGrid, GridItem } from './index';
+
+describe('DashboardGrid', () => {
+  describe('レンダリング', () => {
+    it('子要素をレンダリングする', () => {
+      render(
+        <DashboardGrid>
+          <div>コンテンツ1</div>
+          <div>コンテンツ2</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+      expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+    });
+
+    it('グリッドコンテナとしてレンダリングされる', () => {
+      render(
+        <DashboardGrid data-testid="grid">
+          <div>コンテンツ</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByTestId('grid')).toHaveClass('grid');
+    });
+  });
+
+  describe('レスポンシブグリッド', () => {
+    it('1カラム（モバイル）クラスを持つ', () => {
+      render(
+        <DashboardGrid data-testid="grid">
+          <div>コンテンツ</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByTestId('grid')).toHaveClass('grid-cols-1');
+    });
+
+    it('2カラム（タブレット）クラスを持つ', () => {
+      render(
+        <DashboardGrid data-testid="grid">
+          <div>コンテンツ</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByTestId('grid')).toHaveClass('md:grid-cols-2');
+    });
+
+    it('3カラム（デスクトップ）クラスを持つ', () => {
+      render(
+        <DashboardGrid data-testid="grid">
+          <div>コンテンツ</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByTestId('grid')).toHaveClass('lg:grid-cols-3');
+    });
+  });
+
+  describe('スタイル', () => {
+    it('ギャップが設定されている', () => {
+      render(
+        <DashboardGrid data-testid="grid">
+          <div>コンテンツ</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByTestId('grid')).toHaveClass('gap-6');
+    });
+
+    it('パディングが設定されている', () => {
+      render(
+        <DashboardGrid data-testid="grid">
+          <div>コンテンツ</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByTestId('grid')).toHaveClass('p-6');
+    });
+
+    it('カスタムclassNameを追加できる', () => {
+      render(
+        <DashboardGrid data-testid="grid" className="custom-class">
+          <div>コンテンツ</div>
+        </DashboardGrid>
+      );
+
+      expect(screen.getByTestId('grid')).toHaveClass('custom-class');
+    });
+  });
+});
+
+describe('GridItem', () => {
+  describe('レンダリング', () => {
+    it('子要素をレンダリングする', () => {
+      render(
+        <GridItem>
+          <div>アイテムコンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByText('アイテムコンテンツ')).toBeInTheDocument();
+    });
+  });
+
+  describe('colSpan', () => {
+    it('colSpan=1の場合はスパンクラスを持たない', () => {
+      render(
+        <GridItem data-testid="item" colSpan={1}>
+          <div>コンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByTestId('item')).not.toHaveClass('md:col-span-2');
+      expect(screen.getByTestId('item')).not.toHaveClass('lg:col-span-3');
+    });
+
+    it('colSpan=2の場合はmd:col-span-2を持つ', () => {
+      render(
+        <GridItem data-testid="item" colSpan={2}>
+          <div>コンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByTestId('item')).toHaveClass('md:col-span-2');
+    });
+
+    it('colSpan=3の場合はlg:col-span-3を持つ', () => {
+      render(
+        <GridItem data-testid="item" colSpan={3}>
+          <div>コンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByTestId('item')).toHaveClass('lg:col-span-3');
+    });
+  });
+
+  describe('rowSpan', () => {
+    it('rowSpan=1の場合はrow-spanクラスを持たない', () => {
+      render(
+        <GridItem data-testid="item" rowSpan={1}>
+          <div>コンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByTestId('item')).not.toHaveClass('row-span-2');
+    });
+
+    it('rowSpan=2の場合はrow-span-2を持つ', () => {
+      render(
+        <GridItem data-testid="item" rowSpan={2}>
+          <div>コンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByTestId('item')).toHaveClass('row-span-2');
+    });
+  });
+
+  describe('スタイル', () => {
+    it('カスタムclassNameを追加できる', () => {
+      render(
+        <GridItem data-testid="item" className="custom-item">
+          <div>コンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByTestId('item')).toHaveClass('custom-item');
+    });
+  });
+
+  describe('colSpanとrowSpanの組み合わせ', () => {
+    it('colSpan=2とrowSpan=2を同時に指定できる', () => {
+      render(
+        <GridItem data-testid="item" colSpan={2} rowSpan={2}>
+          <div>コンテンツ</div>
+        </GridItem>
+      );
+
+      expect(screen.getByTestId('item')).toHaveClass('md:col-span-2');
+      expect(screen.getByTestId('item')).toHaveClass('row-span-2');
+    });
+  });
+});

--- a/src/components/layout/DashboardGrid/DashboardGrid.tsx
+++ b/src/components/layout/DashboardGrid/DashboardGrid.tsx
@@ -1,0 +1,22 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from '@/utils';
+
+type DashboardGridProps = {
+  children: React.ReactNode;
+  className?: string;
+} & Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className'>;
+
+/**
+ * ダッシュボードのグリッドレイアウトコンポーネント
+ * レスポンシブ対応: 1→2→3カラム
+ */
+export function DashboardGrid({ children, className, ...props }: DashboardGridProps) {
+  return (
+    <div
+      className={cn('grid gap-6 p-6', 'grid-cols-1', 'md:grid-cols-2', 'lg:grid-cols-3', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/DashboardGrid/GridItem.tsx
+++ b/src/components/layout/DashboardGrid/GridItem.tsx
@@ -1,0 +1,35 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from '@/utils';
+
+type GridItemProps = {
+  children: React.ReactNode;
+  colSpan?: 1 | 2 | 3;
+  rowSpan?: 1 | 2;
+  className?: string;
+} & Omit<ComponentPropsWithoutRef<'div'>, 'children' | 'className'>;
+
+/**
+ * グリッドアイテムコンポーネント
+ * colSpan/rowSpanでグリッドスパンを指定可能
+ */
+export function GridItem({
+  children,
+  colSpan = 1,
+  rowSpan = 1,
+  className,
+  ...props
+}: GridItemProps) {
+  return (
+    <div
+      className={cn(
+        colSpan === 2 && 'md:col-span-2',
+        colSpan === 3 && 'lg:col-span-3',
+        rowSpan === 2 && 'row-span-2',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/DashboardGrid/index.ts
+++ b/src/components/layout/DashboardGrid/index.ts
@@ -1,0 +1,2 @@
+export { DashboardGrid } from './DashboardGrid';
+export { GridItem } from './GridItem';

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,2 +1,5 @@
 // Header
 export { Header } from './Header';
+
+// DashboardGrid
+export { DashboardGrid, GridItem } from './DashboardGrid';


### PR DESCRIPTION
## 概要
ダッシュボードのグリッドレイアウトコンポーネントを実装

## 変更内容
- DashboardGrid: レスポンシブグリッドレイアウト
  - 1カラム（モバイル）→2カラム（タブレット）→3カラム（デスクトップ）
  - gap-6, p-6のスペーシング
- GridItem: グリッドアイテム
  - colSpan (1|2|3) でカラムスパン指定
  - rowSpan (1|2) で行スパン指定
- layout/index.tsでエクスポート追加

## テスト
- 16件の新規テスト追加（全337テストパス）

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)