### PR TITLE
feat(layout): Sectionコンポーネント実装 #21

### DIFF
--- a/src/components/layout/Section/Section.test.tsx
+++ b/src/components/layout/Section/Section.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Section } from './index';
+
+describe('Section', () => {
+  describe('レンダリング', () => {
+    it('section要素としてレンダリングされる', () => {
+      render(
+        <Section title="テスト">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      expect(screen.getByRole('region')).toBeInTheDocument();
+    });
+
+    it('子要素をレンダリングする', () => {
+      render(
+        <Section title="テスト">
+          <div>コンテンツ1</div>
+          <div>コンテンツ2</div>
+        </Section>
+      );
+
+      expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+      expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+    });
+  });
+
+  describe('タイトル', () => {
+    it('タイトルがh2として表示される', () => {
+      render(
+        <Section title="セクションタイトル">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('セクションタイトル');
+    });
+
+    it('タイトルに適切なスタイルが適用される', () => {
+      render(
+        <Section title="テスト">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      const heading = screen.getByRole('heading', { level: 2 });
+      expect(heading).toHaveClass('text-xl');
+      expect(heading).toHaveClass('font-semibold');
+      expect(heading).toHaveClass('text-text-primary');
+    });
+  });
+
+  describe('説明文', () => {
+    it('descriptionが指定されていない場合は説明文が表示されない', () => {
+      render(
+        <Section title="テスト">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      const paragraphs = document.querySelectorAll('p');
+      expect(paragraphs.length).toBe(0);
+    });
+
+    it('descriptionが指定されている場合は説明文が表示される', () => {
+      render(
+        <Section title="テスト" description="セクションの説明文です">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      expect(screen.getByText('セクションの説明文です')).toBeInTheDocument();
+    });
+
+    it('説明文に適切なスタイルが適用される', () => {
+      render(
+        <Section title="テスト" description="説明文">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      const description = screen.getByText('説明文');
+      expect(description).toHaveClass('text-sm');
+      expect(description).toHaveClass('text-text-secondary');
+    });
+  });
+
+  describe('スタイル', () => {
+    it('適切なスペーシングが適用される', () => {
+      render(
+        <Section title="テスト" data-testid="section">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      expect(screen.getByTestId('section')).toHaveClass('space-y-4');
+    });
+
+    it('カスタムclassNameを追加できる', () => {
+      render(
+        <Section title="テスト" className="custom-class" data-testid="section">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      expect(screen.getByTestId('section')).toHaveClass('custom-class');
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('section要素にaria-labelledbyが設定される', () => {
+      render(
+        <Section title="アクセシブルセクション">
+          <div>コンテンツ</div>
+        </Section>
+      );
+
+      const section = screen.getByRole('region');
+      const heading = screen.getByRole('heading', { level: 2 });
+      expect(section).toHaveAttribute('aria-labelledby', heading.id);
+    });
+  });
+});

--- a/src/components/layout/Section/Section.tsx
+++ b/src/components/layout/Section/Section.tsx
@@ -1,0 +1,29 @@
+import { useId, type ComponentPropsWithoutRef } from 'react';
+import { cn } from '@/utils';
+
+type SectionProps = {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  className?: string;
+} & Omit<ComponentPropsWithoutRef<'section'>, 'children' | 'className'>;
+
+/**
+ * セクション区切りコンポーネント
+ * タイトル、説明文、コンテンツをまとめて表示
+ */
+export function Section({ title, description, children, className, ...props }: SectionProps) {
+  const headingId = useId();
+
+  return (
+    <section className={cn('space-y-4', className)} aria-labelledby={headingId} {...props}>
+      <div>
+        <h2 id={headingId} className="text-xl font-semibold text-text-primary">
+          {title}
+        </h2>
+        {description && <p className="text-sm text-text-secondary mt-1">{description}</p>}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/components/layout/Section/index.ts
+++ b/src/components/layout/Section/index.ts
@@ -1,0 +1,1 @@
+export { Section } from './Section';

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -3,3 +3,6 @@ export { Header } from './Header';
 
 // DashboardGrid
 export { DashboardGrid, GridItem } from './DashboardGrid';
+
+// Section
+export { Section } from './Section';


### PR DESCRIPTION
## 概要
セクション区切りコンポーネントを実装

## 変更内容
- Section: セクション区切りコンポーネント
  - タイトル（h2）表示
  - オプショナルな説明文
  - space-y-4スペーシング
  - aria-labelledbyでアクセシビリティ対応
- layout/index.tsでエクスポート追加

## テスト
- 10件の新規テスト追加（全347テストパス）

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)