### PR TITLE
feat(styles): globals.cssとCSS変数定義 #22

### DIFF
--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,0 +1,5 @@
+/* Google Fonts: Noto Sans JP */
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap');
+
+/* JetBrains Mono for monospace */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap');

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,62 @@
+@import 'tailwindcss';
+@import './fonts.css';
+
+:root {
+  /* Colors - Primary */
+  --color-primary: #2d6a4f;
+  --color-primary-light: #40916c;
+  --color-primary-dark: #1b4332;
+
+  /* Colors - Secondary */
+  --color-secondary: #b07d62;
+  --color-secondary-light: #d4a574;
+  --color-secondary-dark: #8b5e3c;
+
+  /* Colors - Semantic */
+  --color-income: #059669;
+  --color-income-light: #d1fae5;
+  --color-expense: #dc2626;
+  --color-expense-light: #fee2e2;
+  --color-warning: #d97706;
+  --color-warning-light: #fef3c7;
+
+  /* Colors - Base */
+  --color-background: #fdfbf7;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f9f7f3;
+  --color-border: #e5e1d8;
+  --color-border-strong: #d1ccc0;
+
+  /* Colors - Text */
+  --color-text-primary: #1f2937;
+  --color-text-secondary: #6b7280;
+  --color-text-tertiary: #9ca3af;
+
+  /* Typography */
+  --font-heading: 'Noto Sans JP', sans-serif;
+  --font-body: 'Noto Sans JP', sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px rgb(0 0 0 / 0.07);
+  --shadow-lg: 0 10px 15px rgb(0 0 0 / 0.1);
+
+  /* Border Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+}
+
+/* Focus visible */
+*:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,2 @@
+// グローバルスタイルのインポート用
+// 使用方法: import '@/styles/globals.css';


### PR DESCRIPTION
## 概要
グローバルCSSとCSS変数を定義

## 変更内容
- globals.css: グローバルスタイル
  - Tailwind CSSインポート
  - カラーパレットのCSS変数（Primary, Secondary, Semantic, Base, Text）
  - タイポグラフィ設定
  - シャドウ・ボーダーラディウス定義
  - フォーカスリング設定
- fonts.css: Webフォント読み込み
  - Noto Sans JP（400, 500, 600, 700）
  - JetBrains Mono（400, 500, 600）

## 備考
main.tsxへのインポートは、main.tsxが作成される時点で追加

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)