### PR TITLE
feat(styles): theme.tsでTailwindテーマ定義を集約 #23

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,88 @@
+/**
+ * Tailwind CSS拡張用のテーマ定義
+ * tailwind.config.ts で使用
+ */
+
+export const colors = {
+  // Primary
+  primary: {
+    DEFAULT: '#2D6A4F',
+    light: '#40916C',
+    dark: '#1B4332',
+  },
+  // Secondary
+  secondary: {
+    DEFAULT: '#B07D62',
+    light: '#D4A574',
+    dark: '#8B5E3C',
+  },
+  // Semantic
+  income: {
+    DEFAULT: '#059669',
+    light: '#D1FAE5',
+  },
+  expense: {
+    DEFAULT: '#DC2626',
+    light: '#FEE2E2',
+  },
+  warning: {
+    DEFAULT: '#D97706',
+    light: '#FEF3C7',
+  },
+  // Base
+  background: '#FDFBF7',
+  surface: {
+    DEFAULT: '#FFFFFF',
+    hover: '#F9F7F3',
+  },
+  border: {
+    DEFAULT: '#E5E1D8',
+    strong: '#D1CCC0',
+  },
+  // Text
+  'text-primary': '#1F2937',
+  'text-secondary': '#6B7280',
+  'text-tertiary': '#9CA3AF',
+};
+
+export const fontFamily = {
+  heading: ['Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'sans-serif'],
+  body: ['Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'sans-serif'],
+  mono: ['JetBrains Mono', 'SF Mono', 'Consolas', 'monospace'],
+};
+
+export const fontSize = {
+  display: ['2rem', { lineHeight: '1.2' }] as const,
+  h1: ['1.5rem', { lineHeight: '1.3' }] as const,
+  h2: ['1.25rem', { lineHeight: '1.4' }] as const,
+  h3: ['1rem', { lineHeight: '1.4' }] as const,
+  body: ['0.875rem', { lineHeight: '1.6' }] as const,
+  small: ['0.75rem', { lineHeight: '1.5' }] as const,
+  tiny: ['0.625rem', { lineHeight: '1.4' }] as const,
+};
+
+export const borderRadius = {
+  sm: '4px',
+  md: '8px',
+  lg: '12px',
+  xl: '16px',
+};
+
+export const boxShadow = {
+  sm: '0 1px 2px rgba(0,0,0,0.05)',
+  md: '0 4px 6px rgba(0,0,0,0.07)',
+  lg: '0 10px 15px rgba(0,0,0,0.1)',
+  xl: '0 20px 25px rgba(0,0,0,0.1)',
+};
+
+export const spacing = {
+  1: '4px',
+  2: '8px',
+  3: '12px',
+  4: '16px',
+  5: '20px',
+  6: '24px',
+  8: '32px',
+  10: '40px',
+  12: '48px',
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,87 +1,16 @@
 import type { Config } from 'tailwindcss';
+import { colors, fontFamily, fontSize, borderRadius, boxShadow, spacing } from './src/styles/theme';
 
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
-      colors: {
-        // Primary
-        primary: {
-          DEFAULT: '#2D6A4F',
-          light: '#40916C',
-          dark: '#1B4332',
-        },
-        // Secondary
-        secondary: {
-          DEFAULT: '#B07D62',
-          light: '#D4A574',
-          dark: '#8B5E3C',
-        },
-        // Semantic
-        income: {
-          DEFAULT: '#059669',
-          light: '#D1FAE5',
-        },
-        expense: {
-          DEFAULT: '#DC2626',
-          light: '#FEE2E2',
-        },
-        warning: {
-          DEFAULT: '#D97706',
-          light: '#FEF3C7',
-        },
-        // Base
-        background: '#FDFBF7',
-        surface: {
-          DEFAULT: '#FFFFFF',
-          hover: '#F9F7F3',
-        },
-        border: {
-          DEFAULT: '#E5E1D8',
-          strong: '#D1CCC0',
-        },
-        // Text
-        'text-primary': '#1F2937',
-        'text-secondary': '#6B7280',
-        'text-tertiary': '#9CA3AF',
-      },
-      fontFamily: {
-        heading: ['Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'sans-serif'],
-        body: ['Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'sans-serif'],
-        mono: ['JetBrains Mono', 'SF Mono', 'Consolas', 'monospace'],
-      },
-      fontSize: {
-        display: ['2rem', { lineHeight: '1.2' }],
-        h1: ['1.5rem', { lineHeight: '1.3' }],
-        h2: ['1.25rem', { lineHeight: '1.4' }],
-        h3: ['1rem', { lineHeight: '1.4' }],
-        body: ['0.875rem', { lineHeight: '1.6' }],
-        small: ['0.75rem', { lineHeight: '1.5' }],
-        tiny: ['0.625rem', { lineHeight: '1.4' }],
-      },
-      borderRadius: {
-        sm: '4px',
-        md: '8px',
-        lg: '12px',
-        xl: '16px',
-      },
-      boxShadow: {
-        sm: '0 1px 2px rgba(0,0,0,0.05)',
-        md: '0 4px 6px rgba(0,0,0,0.07)',
-        lg: '0 10px 15px rgba(0,0,0,0.1)',
-        xl: '0 20px 25px rgba(0,0,0,0.1)',
-      },
-      spacing: {
-        1: '4px',
-        2: '8px',
-        3: '12px',
-        4: '16px',
-        5: '20px',
-        6: '24px',
-        8: '32px',
-        10: '40px',
-        12: '48px',
-      },
+      colors,
+      fontFamily,
+      fontSize,
+      borderRadius,
+      boxShadow,
+      spacing,
     },
   },
   plugins: [],


### PR DESCRIPTION
## 概要
Tailwindテーマ定義をtheme.tsに集約

## 変更内容
- theme.ts: Tailwind拡張用テーマ定義を作成
  - colors: カラーパレット
  - fontFamily: フォントファミリー
  - fontSize: フォントサイズ
  - borderRadius: 角丸
  - boxShadow: シャドウ
  - spacing: スペーシング
- tailwind.config.ts: theme.tsをインポートして使用

## テスト
- 全347テストパス

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)