### PR TITLE
feat(contexts): TransactionContext実装 #24

### DIFF
--- a/src/contexts/TransactionContext.test.tsx
+++ b/src/contexts/TransactionContext.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, renderHook } from '@testing-library/react';
+import { TransactionProvider, useTransactionContext } from './TransactionContext';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+// Mock loadTransactions
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransaction: Transaction = {
+  id: 'test-1',
+  date: new Date('2025-01-15'),
+  description: 'テスト取引',
+  amount: -1000,
+  institution: 'テスト銀行',
+  category: '食費',
+  subcategory: '食料品',
+  memo: '',
+  isTransfer: false,
+  isCalculated: true,
+};
+
+describe('TransactionContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('TransactionProvider', () => {
+    it('子要素をレンダリングする', async () => {
+      vi.mocked(services.loadTransactions).mockResolvedValue([]);
+
+      render(
+        <TransactionProvider>
+          <div>テスト子要素</div>
+        </TransactionProvider>
+      );
+
+      expect(screen.getByText('テスト子要素')).toBeInTheDocument();
+    });
+
+    it('初期ロード時にloadTransactionsを呼び出す', async () => {
+      vi.mocked(services.loadTransactions).mockResolvedValue([mockTransaction]);
+
+      render(
+        <TransactionProvider>
+          <div>テスト</div>
+        </TransactionProvider>
+      );
+
+      await waitFor(() => {
+        expect(services.loadTransactions).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('useTransactionContext', () => {
+    it('初期状態はローディング中', () => {
+      vi.mocked(services.loadTransactions).mockReturnValue(
+        new Promise(() => {}) // Never resolves
+      );
+
+      const { result } = renderHook(() => useTransactionContext(), {
+        wrapper: TransactionProvider,
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.transactions).toEqual([]);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('データ読み込み完了後にトランザクションを返す', async () => {
+      vi.mocked(services.loadTransactions).mockResolvedValue([mockTransaction]);
+
+      const { result } = renderHook(() => useTransactionContext(), {
+        wrapper: TransactionProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.transactions).toEqual([mockTransaction]);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('エラー発生時にエラー状態を設定する', async () => {
+      const error = new Error('読み込みエラー');
+      vi.mocked(services.loadTransactions).mockRejectedValue(error);
+
+      const { result } = renderHook(() => useTransactionContext(), {
+        wrapper: TransactionProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.error).toEqual(error);
+      expect(result.current.transactions).toEqual([]);
+    });
+
+    it('reload関数で再読み込みできる', async () => {
+      vi.mocked(services.loadTransactions)
+        .mockResolvedValueOnce([mockTransaction])
+        .mockResolvedValueOnce([mockTransaction, { ...mockTransaction, id: 'test-2' }]);
+
+      const { result } = renderHook(() => useTransactionContext(), {
+        wrapper: TransactionProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.transactions).toHaveLength(1);
+      });
+
+      await result.current.reload();
+
+      await waitFor(() => {
+        expect(result.current.transactions).toHaveLength(2);
+      });
+
+      expect(services.loadTransactions).toHaveBeenCalledTimes(2);
+    });
+
+    it('Provider外で使用時にエラーをスローする', () => {
+      // Suppress console.error for this test
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useTransactionContext());
+      }).toThrow('useTransactionContext must be used within TransactionProvider');
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/contexts/TransactionContext.tsx
+++ b/src/contexts/TransactionContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import type { Transaction } from '@/types';
+import { loadTransactions } from '@/services';
+
+type TransactionContextValue = {
+  transactions: Transaction[];
+  isLoading: boolean;
+  error: Error | null;
+  reload: () => Promise<void>;
+};
+
+const TransactionContext = createContext<TransactionContextValue | null>(null);
+
+export function TransactionProvider({ children }: { children: ReactNode }) {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await loadTransactions();
+      setTransactions(data);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <TransactionContext.Provider value={{ transactions, isLoading, error, reload: load }}>
+      {children}
+    </TransactionContext.Provider>
+  );
+}
+
+export function useTransactionContext(): TransactionContextValue {
+  const context = useContext(TransactionContext);
+  if (!context) {
+    throw new Error('useTransactionContext must be used within TransactionProvider');
+  }
+  return context;
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export { TransactionProvider, useTransactionContext } from './TransactionContext';


### PR DESCRIPTION
## 概要
トランザクションデータを管理するReactコンテキストを実装

## 変更内容
- TransactionProvider: トランザクションデータのProvider
  - 初期ロード時にloadTransactionsを呼び出し
  - ローディング状態管理
  - エラー状態管理
  - reload関数で再読み込み対応
- useTransactionContext: コンテキスト値を取得するフック
  - Provider外で使用時にエラーをスロー
- contexts/index.tsでエクスポート

## テスト
- 7件の新規テスト追加（全354テストパス）

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)