### PR TITLE
feat(contexts): FilterContext実装 #25

### DIFF
--- a/src/contexts/FilterContext.test.tsx
+++ b/src/contexts/FilterContext.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { FilterProvider, useFilterContext } from './FilterContext';
+
+describe('FilterContext', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <FilterProvider>{children}</FilterProvider>
+  );
+
+  describe('初期値', () => {
+    it('デフォルト値が設定される', () => {
+      const { result } = renderHook(() => useFilterContext(), { wrapper });
+
+      expect(result.current.filters).toEqual({
+        year: new Date().getFullYear(),
+        month: 'all',
+        category: 'all',
+        institution: 'all',
+        searchQuery: '',
+      });
+    });
+  });
+
+  describe('setFilters', () => {
+    it('フィルター全体を更新できる', () => {
+      const { result } = renderHook(() => useFilterContext(), { wrapper });
+
+      act(() => {
+        result.current.setFilters({
+          year: 2024,
+          month: 12,
+          category: '食費',
+          institution: '三菱UFJ銀行',
+          searchQuery: 'スーパー',
+        });
+      });
+
+      expect(result.current.filters).toEqual({
+        year: 2024,
+        month: 12,
+        category: '食費',
+        institution: '三菱UFJ銀行',
+        searchQuery: 'スーパー',
+      });
+    });
+  });
+
+  describe('updateFilter', () => {
+    it('単一フィールドを更新できる', () => {
+      const { result } = renderHook(() => useFilterContext(), { wrapper });
+
+      act(() => {
+        result.current.updateFilter('month', 6);
+      });
+
+      expect(result.current.filters.month).toBe(6);
+      expect(result.current.filters.category).toBe('all'); // 他のフィールドは変わらない
+    });
+
+    it('yearを更新できる', () => {
+      const { result } = renderHook(() => useFilterContext(), { wrapper });
+
+      act(() => {
+        result.current.updateFilter('year', 2024);
+      });
+
+      expect(result.current.filters.year).toBe(2024);
+    });
+
+    it('categoryを更新できる', () => {
+      const { result } = renderHook(() => useFilterContext(), { wrapper });
+
+      act(() => {
+        result.current.updateFilter('category', '食費');
+      });
+
+      expect(result.current.filters.category).toBe('食費');
+    });
+
+    it('searchQueryを更新できる', () => {
+      const { result } = renderHook(() => useFilterContext(), { wrapper });
+
+      act(() => {
+        result.current.updateFilter('searchQuery', 'コンビニ');
+      });
+
+      expect(result.current.filters.searchQuery).toBe('コンビニ');
+    });
+  });
+
+  describe('resetFilters', () => {
+    it('デフォルト値にリセットできる', () => {
+      const { result } = renderHook(() => useFilterContext(), { wrapper });
+
+      // まず変更
+      act(() => {
+        result.current.setFilters({
+          year: 2024,
+          month: 6,
+          category: '食費',
+          institution: '楽天カード',
+          searchQuery: 'テスト',
+        });
+      });
+
+      // リセット
+      act(() => {
+        result.current.resetFilters();
+      });
+
+      expect(result.current.filters).toEqual({
+        year: new Date().getFullYear(),
+        month: 'all',
+        category: 'all',
+        institution: 'all',
+        searchQuery: '',
+      });
+    });
+  });
+
+  describe('エラー処理', () => {
+    it('Provider外で使用時にエラーをスローする', () => {
+      // Suppress console.error for this test
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useFilterContext());
+      }).toThrow('useFilterContext must be used within FilterProvider');
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/contexts/FilterContext.tsx
+++ b/src/contexts/FilterContext.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import type { FilterState } from '@/types';
+import { FilterStateSchema } from '@/schemas';
+
+const defaultFilters: FilterState = {
+  year: new Date().getFullYear(),
+  month: 'all',
+  category: 'all',
+  institution: 'all',
+  searchQuery: '',
+};
+
+type FilterContextValue = {
+  filters: FilterState;
+  setFilters: (filters: FilterState) => void;
+  resetFilters: () => void;
+  updateFilter: <K extends keyof FilterState>(key: K, value: FilterState[K]) => void;
+};
+
+const FilterContext = createContext<FilterContextValue | null>(null);
+
+export function FilterProvider({ children }: { children: ReactNode }) {
+  const [filters, _setFilters] = useState<FilterState>(defaultFilters);
+
+  const setFilters = useCallback((newFilters: FilterState) => {
+    const validated = FilterStateSchema.parse(newFilters);
+    _setFilters(validated);
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    _setFilters(defaultFilters);
+  }, []);
+
+  const updateFilter = useCallback(<K extends keyof FilterState>(key: K, value: FilterState[K]) => {
+    _setFilters((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  return (
+    <FilterContext.Provider value={{ filters, setFilters, resetFilters, updateFilter }}>
+      {children}
+    </FilterContext.Provider>
+  );
+}
+
+export function useFilterContext(): FilterContextValue {
+  const context = useContext(FilterContext);
+  if (!context) {
+    throw new Error('useFilterContext must be used within FilterProvider');
+  }
+  return context;
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,1 +1,2 @@
 export { TransactionProvider, useTransactionContext } from './TransactionContext';
+export { FilterProvider, useFilterContext } from './FilterContext';


### PR DESCRIPTION
## 概要
フィルター状態を管理するReactコンテキストを実装

## 変更内容
- FilterProvider: フィルター状態のProvider
  - デフォルト値（現在年、all）で初期化
  - setFiltersでバリデーション付き更新
  - updateFilterで単一フィールド更新
  - resetFiltersでデフォルトにリセット
- useFilterContext: コンテキスト値を取得するフック
  - Provider外で使用時にエラーをスロー
- contexts/index.tsでエクスポート追加

## テスト
- 8件の新規テスト追加（全362テストパス）

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)