### PR TITLE
feat(hooks): useFilteredDataフック実装 #27

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useTransactions } from './useTransactions';
+export { useFilteredData } from './useFilteredData';

--- a/src/hooks/useFilteredData.test.tsx
+++ b/src/hooks/useFilteredData.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useFilteredData } from './useFilteredData';
+import { TransactionProvider, FilterProvider, useFilterContext } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: 'テスト取引1',
+    amount: -1000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-02-20'),
+    description: 'テスト取引2',
+    amount: -2000,
+    institution: '楽天カード',
+    category: '日用品',
+    subcategory: '雑貨',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-3',
+    date: new Date('2025-01-25'),
+    description: 'テスト取引3',
+    amount: 50000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('useFilteredData', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('全データを返す（フィルターなし）', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { result } = renderHook(() => useFilteredData(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data.length).toBe(3);
+    });
+
+    expect(result.current.totalCount).toBe(3);
+    expect(result.current.filteredCount).toBe(3);
+  });
+
+  it('カテゴリでフィルターできる', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { result } = renderHook(
+      () => {
+        const filtered = useFilteredData();
+        const filter = useFilterContext();
+        return { filtered, filter };
+      },
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.filtered.data.length).toBe(3);
+    });
+
+    act(() => {
+      result.current.filter.updateFilter('category', '食費');
+    });
+
+    await waitFor(() => {
+      expect(result.current.filtered.filteredCount).toBe(1);
+    });
+
+    expect(result.current.filtered.data[0].category).toBe('食費');
+    expect(result.current.filtered.totalCount).toBe(3);
+  });
+
+  it('月でフィルターできる', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { result } = renderHook(
+      () => {
+        const filtered = useFilteredData();
+        const filter = useFilterContext();
+        return { filtered, filter };
+      },
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.filtered.data.length).toBe(3);
+    });
+
+    act(() => {
+      result.current.filter.updateFilter('month', 1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.filtered.filteredCount).toBe(2);
+    });
+
+    expect(result.current.filtered.totalCount).toBe(3);
+  });
+});

--- a/src/hooks/useFilteredData.ts
+++ b/src/hooks/useFilteredData.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { useTransactionContext, useFilterContext } from '@/contexts';
+import { applyFilters } from '@/utils/filters';
+import type { Transaction } from '@/types';
+
+type UseFilteredDataReturn = {
+  data: Transaction[];
+  totalCount: number;
+  filteredCount: number;
+};
+
+/**
+ * フィルター適用済みデータを取得
+ */
+export function useFilteredData(): UseFilteredDataReturn {
+  const { transactions } = useTransactionContext();
+  const { filters } = useFilterContext();
+
+  const filteredData = useMemo(() => {
+    return applyFilters(transactions, filters);
+  }, [transactions, filters]);
+
+  return {
+    data: filteredData,
+    totalCount: transactions.length,
+    filteredCount: filteredData.length,
+  };
+}


### PR DESCRIPTION
## 概要
フィルター適用済みデータを取得するフック

## 変更内容
- useFilteredData: FilterContextのフィルターを適用
  - data: フィルター適用済みデータ
  - totalCount: 全データ件数
  - filteredCount: フィルター後件数
  - useMemoでメモ化

## テスト
- 3件の新規テスト追加（全368テストパス）

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)