### PR TITLE
feat(hooks): useInstitutionSummaryフック実装 #30

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useTransactions } from './useTransactions';
 export { useFilteredData } from './useFilteredData';
 export { useMonthlySummary } from './useMonthlySummary';
 export { useCategorySummary } from './useCategorySummary';
+export { useInstitutionSummary } from './useInstitutionSummary';

--- a/src/hooks/useInstitutionSummary.test.tsx
+++ b/src/hooks/useInstitutionSummary.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useInstitutionSummary } from './useInstitutionSummary';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食費1',
+    amount: -30000,
+    institution: '三菱UFJ銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '食費2',
+    amount: -20000,
+    institution: '楽天カード',
+    category: '食費',
+    subcategory: '外食',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-3',
+    date: new Date('2025-01-25'),
+    description: '日用品',
+    amount: -10000,
+    institution: '三菱UFJ銀行',
+    category: '日用品',
+    subcategory: '雑貨',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-4',
+    date: new Date('2025-01-25'),
+    description: '給与',
+    amount: 300000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('useInstitutionSummary', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('金融機関別サマリーを返す', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { result } = renderHook(() => useInstitutionSummary(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    // 三菱UFJ銀行のサマリーを確認（30000 + 10000 = 40000）
+    const ufj = result.current.find((s) => s.institution === '三菱UFJ銀行');
+    expect(ufj).toBeDefined();
+    expect(ufj?.amount).toBe(40000);
+  });
+
+  it('金額降順でソートされている', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { result } = renderHook(() => useInstitutionSummary(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.length).toBe(2); // 三菱UFJ銀行と楽天カード（収入は除外）
+    });
+
+    // 金額降順を確認
+    expect(result.current[0].institution).toBe('三菱UFJ銀行');
+    expect(result.current[0].amount).toBe(40000);
+    expect(result.current[1].institution).toBe('楽天カード');
+    expect(result.current[1].amount).toBe(20000);
+  });
+
+  it('割合を計算する', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { result } = renderHook(() => useInstitutionSummary(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.length).toBe(2);
+    });
+
+    // 割合を確認: 三菱UFJ銀行 40000 / (40000 + 20000) = 0.666...
+    const ufj = result.current.find((s) => s.institution === '三菱UFJ銀行');
+    expect(ufj?.percentage).toBeCloseTo(40000 / 60000);
+
+    // 楽天カード 20000 / 60000 = 0.333...
+    const rakuten = result.current.find((s) => s.institution === '楽天カード');
+    expect(rakuten?.percentage).toBeCloseTo(20000 / 60000);
+  });
+});

--- a/src/hooks/useInstitutionSummary.ts
+++ b/src/hooks/useInstitutionSummary.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useFilteredData } from './useFilteredData';
+import type { InstitutionSummary } from '@/types';
+
+/**
+ * 金融機関別サマリーを計算
+ * @returns 金融機関別サマリー配列（金額降順）
+ */
+export function useInstitutionSummary(): InstitutionSummary[] {
+  const { data } = useFilteredData();
+
+  return useMemo(() => {
+    // 支出のみを対象
+    const expenses = data.filter((t) => t.amount < 0);
+
+    if (expenses.length === 0) {
+      return [];
+    }
+
+    const total = expenses.reduce((sum, t) => sum + Math.abs(t.amount), 0);
+
+    // 金融機関別に集計
+    const byInstitution = new Map<string, number>();
+    for (const t of expenses) {
+      const current = byInstitution.get(t.institution) ?? 0;
+      byInstitution.set(t.institution, current + Math.abs(t.amount));
+    }
+
+    // 配列に変換してソート
+    return Array.from(byInstitution.entries())
+      .map(([institution, amount]) => ({
+        institution,
+        amount,
+        percentage: total > 0 ? amount / total : 0,
+      }))
+      .sort((a, b) => b.amount - a.amount);
+  }, [data]);
+}


### PR DESCRIPTION
## Summary

- 金融機関別サマリーを計算する`useInstitutionSummary`フックを実装
- 支出のみを対象に金融機関ごとに金額と割合を計算
- 金額降順でソート
- テスト3件追加

## Test plan

- [x] `useInstitutionSummary`フックが正しく金融機関別サマリーを返す
- [x] 金額降順でソートされている
- [x] 割合が正しく計算される
- [x] 全377テストがパス

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)