### PR TITLE
feat(hooks): useTrendフック実装 #32

### DIFF
--- a/src/contexts/FilterContext.tsx
+++ b/src/contexts/FilterContext.tsx
@@ -19,8 +19,13 @@ type FilterContextValue = {
 
 const FilterContext = createContext<FilterContextValue | null>(null);
 
-export function FilterProvider({ children }: { children: ReactNode }) {
-  const [filters, _setFilters] = useState<FilterState>(defaultFilters);
+type FilterProviderProps = {
+  children: ReactNode;
+  initialFilters?: FilterState;
+};
+
+export function FilterProvider({ children, initialFilters }: FilterProviderProps) {
+  const [filters, _setFilters] = useState<FilterState>(initialFilters ?? defaultFilters);
 
   const setFilters = useCallback((newFilters: FilterState) => {
     const validated = FilterStateSchema.parse(newFilters);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useMonthlySummary } from './useMonthlySummary';
 export { useCategorySummary } from './useCategorySummary';
 export { useInstitutionSummary } from './useInstitutionSummary';
 export { useRanking } from './useRanking';
+export { useTrend } from './useTrend';

--- a/src/hooks/useTrend.test.tsx
+++ b/src/hooks/useTrend.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTrend } from './useTrend';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  // 1月のデータ
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '給与',
+    amount: 300000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '食費',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  // 2月のデータ
+  {
+    id: 'test-3',
+    date: new Date('2025-02-15'),
+    description: '給与',
+    amount: 330000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-4',
+    date: new Date('2025-02-20'),
+    description: '食費',
+    amount: -33000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('useTrend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('月指定時は前月比を返す', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    // 2月を選択した場合、1月との比較
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TransactionProvider>
+        <FilterProvider
+          initialFilters={{
+            year: 2025,
+            month: 2,
+            category: 'all',
+            institution: 'all',
+            searchQuery: '',
+          }}
+        >
+          {children}
+        </FilterProvider>
+      </TransactionProvider>
+    );
+
+    const { result } = renderHook(() => useTrend(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.income).not.toBe(0);
+    });
+
+    // 収入: 330000 vs 300000 = +10%
+    expect(result.current.income).toBeCloseTo(0.1);
+    // 支出: 33000 vs 30000 = +10%
+    expect(result.current.expense).toBeCloseTo(0.1);
+  });
+
+  it('全期間選択時は0を返す', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TransactionProvider>
+        <FilterProvider
+          initialFilters={{
+            year: 2025,
+            month: 'all',
+            category: 'all',
+            institution: 'all',
+            searchQuery: '',
+          }}
+        >
+          {children}
+        </FilterProvider>
+      </TransactionProvider>
+    );
+
+    const { result } = renderHook(() => useTrend(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+    });
+
+    expect(result.current.income).toBe(0);
+    expect(result.current.expense).toBe(0);
+    expect(result.current.balance).toBe(0);
+  });
+
+  it('前月データがない場合は0を返す', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    // 1月を選択した場合、前月（12月）のデータがない
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TransactionProvider>
+        <FilterProvider
+          initialFilters={{
+            year: 2025,
+            month: 1,
+            category: 'all',
+            institution: 'all',
+            searchQuery: '',
+          }}
+        >
+          {children}
+        </FilterProvider>
+      </TransactionProvider>
+    );
+
+    const { result } = renderHook(() => useTrend(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+    });
+
+    // 前月データがないので変化率は0
+    expect(result.current.income).toBe(0);
+    expect(result.current.expense).toBe(0);
+    expect(result.current.balance).toBe(0);
+  });
+});

--- a/src/hooks/useTrend.ts
+++ b/src/hooks/useTrend.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import { useTransactionContext, useFilterContext } from '@/contexts';
+import { calcTrend, calcIncome, calcExpense } from '@/utils/calculations';
+import type { TrendData } from '@/types';
+
+/**
+ * 前月比を計算
+ * @returns 収入・支出・収支の変化率
+ */
+export function useTrend(): TrendData {
+  const { transactions } = useTransactionContext();
+  const { filters } = useFilterContext();
+
+  return useMemo(() => {
+    // 全期間の場合は比較できないので0を返す
+    if (filters.month === 'all') {
+      return { income: 0, expense: 0, balance: 0 };
+    }
+
+    const currentMonth = filters.month;
+    const currentYear = filters.year;
+
+    // 前月を計算
+    let previousMonth = currentMonth - 1;
+    let previousYear = currentYear;
+    if (previousMonth < 1) {
+      previousMonth = 12;
+      previousYear = currentYear - 1;
+    }
+
+    // 当月のトランザクション
+    const currentTransactions = transactions.filter((t) => {
+      const tYear = t.date.getFullYear();
+      const tMonth = t.date.getMonth() + 1;
+      return tYear === currentYear && tMonth === currentMonth;
+    });
+
+    // 前月のトランザクション
+    const previousTransactions = transactions.filter((t) => {
+      const tYear = t.date.getFullYear();
+      const tMonth = t.date.getMonth() + 1;
+      return tYear === previousYear && tMonth === previousMonth;
+    });
+
+    // 収入・支出を計算
+    const currentIncome = calcIncome(currentTransactions);
+    const currentExpense = calcExpense(currentTransactions);
+    const previousIncome = calcIncome(previousTransactions);
+    const previousExpense = calcExpense(previousTransactions);
+
+    return calcTrend(currentIncome, currentExpense, previousIncome, previousExpense);
+  }, [transactions, filters.year, filters.month]);
+}


### PR DESCRIPTION
## Summary

- 前月比トレンドを計算する`useTrend`フックを実装
- 当月と前月の収入・支出を比較して変化率を計算
- 全期間選択時は0を返す
- `FilterProvider`に`initialFilters`プロパティを追加（テスト用）
- テスト3件追加

## Test plan

- [x] 月指定時は前月比を返す
- [x] 全期間選択時は0を返す
- [x] 前月データがない場合は0を返す
- [x] 全384テストがパス

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)