### PR TITLE
feat(hooks): useChartDataフック実装 #33

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useCategorySummary } from './useCategorySummary';
 export { useInstitutionSummary } from './useInstitutionSummary';
 export { useRanking } from './useRanking';
 export { useTrend } from './useTrend';
+export { useChartData } from './useChartData';

--- a/src/hooks/useChartData.test.tsx
+++ b/src/hooks/useChartData.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useChartData } from './useChartData';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+import { useCallback } from 'react';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食費1',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '給与',
+    amount: 300000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('useChartData', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('変換関数でデータを変換する', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    // 件数を返す変換関数
+    const transformer = (data: Transaction[]) => data.length;
+
+    const { result } = renderHook(() => useChartData(useCallback(transformer, [])), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBe(2);
+    });
+  });
+
+  it('ジェネリック型で任意の変換結果を返せる', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    type ChartPoint = { label: string; value: number };
+
+    // ChartPoint配列に変換する関数
+    const transformer = (data: Transaction[]): ChartPoint[] => {
+      return data.map((t) => ({
+        label: t.description,
+        value: Math.abs(t.amount),
+      }));
+    };
+
+    const { result } = renderHook(() => useChartData(useCallback(transformer, [])), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.length).toBe(2);
+    });
+
+    expect(result.current[0]).toEqual({ label: '食費1', value: 30000 });
+    expect(result.current[1]).toEqual({ label: '給与', value: 300000 });
+  });
+
+  it('カテゴリ別集計を返せる', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    // カテゴリ別に集計する変換関数
+    const transformer = (data: Transaction[]): Record<string, number> => {
+      return data.reduce(
+        (acc, t) => {
+          const category = t.category;
+          acc[category] = (acc[category] || 0) + Math.abs(t.amount);
+          return acc;
+        },
+        {} as Record<string, number>
+      );
+    };
+
+    const { result } = renderHook(() => useChartData(useCallback(transformer, [])), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current['食費']).toBe(30000);
+    });
+
+    expect(result.current['収入']).toBe(300000);
+  });
+});

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useFilteredData } from './useFilteredData';
+import type { Transaction } from '@/types';
+
+/**
+ * データをチャート用に変換する汎用フック
+ * @param transformer 変換関数
+ * @returns 変換済みチャートデータ
+ */
+export function useChartData<T>(transformer: (data: Transaction[]) => T): T {
+  const { data } = useFilteredData();
+
+  return useMemo(() => {
+    return transformer(data);
+  }, [data, transformer]);
+}


### PR DESCRIPTION
## Summary

- チャート用データ変換の汎用`useChartData`フックを実装
- ジェネリック型で任意の変換結果を返せる
- `useMemo`でメモ化
- テスト3件追加

## Test plan

- [x] 変換関数でデータを変換する
- [x] ジェネリック型で任意の変換結果を返せる
- [x] カテゴリ別集計を返せる
- [x] 全387テストがパス

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)