### PR TITLE
feat(charts): ChartContainerコンポーネント実装 #34

### DIFF
--- a/src/components/charts/ChartContainer/ChartContainer.test.tsx
+++ b/src/components/charts/ChartContainer/ChartContainer.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ChartContainer } from './ChartContainer';
+
+describe('ChartContainer', () => {
+  it('タイトルを表示する', () => {
+    render(
+      <ChartContainer title="月別収支推移">
+        <div>Chart content</div>
+      </ChartContainer>
+    );
+
+    expect(screen.getByText('月別収支推移')).toBeInTheDocument();
+  });
+
+  it('説明を表示する', () => {
+    render(
+      <ChartContainer title="月別収支推移" description="2025年の収支推移">
+        <div>Chart content</div>
+      </ChartContainer>
+    );
+
+    expect(screen.getByText('2025年の収支推移')).toBeInTheDocument();
+  });
+
+  it('説明がない場合は表示しない', () => {
+    render(
+      <ChartContainer title="月別収支推移">
+        <div>Chart content</div>
+      </ChartContainer>
+    );
+
+    // 説明要素が存在しないことを確認
+    const description = screen.queryByText('2025年の収支推移');
+    expect(description).not.toBeInTheDocument();
+  });
+
+  it('子要素を表示する', () => {
+    render(
+      <ChartContainer title="月別収支推移">
+        <div data-testid="chart-content">Chart content</div>
+      </ChartContainer>
+    );
+
+    expect(screen.getByTestId('chart-content')).toBeInTheDocument();
+  });
+
+  it('デフォルトの高さは400px', () => {
+    render(
+      <ChartContainer title="月別収支推移">
+        <div>Chart content</div>
+      </ChartContainer>
+    );
+
+    const chartArea = screen.getByText('Chart content').parentElement;
+    expect(chartArea).toHaveStyle({ height: '400px' });
+  });
+
+  it('高さを指定できる', () => {
+    render(
+      <ChartContainer title="月別収支推移" height={300}>
+        <div>Chart content</div>
+      </ChartContainer>
+    );
+
+    const chartArea = screen.getByText('Chart content').parentElement;
+    expect(chartArea).toHaveStyle({ height: '300px' });
+  });
+
+  it('カスタムclassNameを適用できる', () => {
+    render(
+      <ChartContainer title="月別収支推移" className="custom-class" data-testid="container">
+        <div>Chart content</div>
+      </ChartContainer>
+    );
+
+    // CardにclassNameが渡されることを確認
+    expect(screen.getByTestId('container')).toHaveClass('custom-class');
+  });
+});

--- a/src/components/charts/ChartContainer/ChartContainer.tsx
+++ b/src/components/charts/ChartContainer/ChartContainer.tsx
@@ -1,0 +1,30 @@
+import { Card } from '@/components/ui';
+import { cn } from '@/utils';
+import type { ComponentProps } from 'react';
+
+type ChartContainerProps = {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  height?: number;
+  className?: string;
+} & Omit<ComponentProps<typeof Card>, 'children'>;
+
+export function ChartContainer({
+  title,
+  description,
+  children,
+  height = 400,
+  className,
+  ...props
+}: ChartContainerProps) {
+  return (
+    <Card className={cn(className)} {...props}>
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-text-primary">{title}</h3>
+        {description && <p className="text-sm text-text-secondary mt-1">{description}</p>}
+      </div>
+      <div style={{ height }}>{children}</div>
+    </Card>
+  );
+}

--- a/src/components/charts/ChartContainer/index.ts
+++ b/src/components/charts/ChartContainer/index.ts
@@ -1,0 +1,1 @@
+export { ChartContainer } from './ChartContainer';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -1,0 +1,1 @@
+export { ChartContainer } from './ChartContainer';


### PR DESCRIPTION
## Summary

- 共通チャートラッパー`ChartContainer`コンポーネントを実装
- タイトルと説明を表示
- 高さを指定可能（デフォルト400px）
- `charts/index.ts`を新規作成
- テスト7件追加

## Test plan

- [x] タイトルを表示する
- [x] 説明を表示する
- [x] 説明がない場合は表示しない
- [x] 子要素を表示する
- [x] デフォルトの高さは400px
- [x] 高さを指定できる
- [x] カスタムclassNameを適用できる
- [x] 全394テストがパス

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)