### PR TITLE
feat(charts): CategoryPieChartコンポーネントを追加 #36

### DIFF
--- a/src/components/charts/CategoryPieChart/CategoryPieChart.test.tsx
+++ b/src/components/charts/CategoryPieChart/CategoryPieChart.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CategoryPieChart } from './CategoryPieChart';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+// ResizeObserverのモック
+beforeEach(() => {
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食費',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '日用品',
+    amount: -10000,
+    institution: 'テスト銀行',
+    category: '日用品',
+    subcategory: '雑貨',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('CategoryPieChart', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイトルを表示する', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<CategoryPieChart />, { wrapper });
+
+    expect(screen.getByText('カテゴリ別支出')).toBeInTheDocument();
+  });
+
+  it('ChartContainerでラップされている', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { container } = render(<CategoryPieChart />, { wrapper });
+
+    // ChartContainerのCardが存在する
+    expect(container.querySelector('[class*="rounded"]')).toBeInTheDocument();
+  });
+
+  it('RechartsのResponsiveContainerがレンダリングされる', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<CategoryPieChart />, { wrapper });
+
+    // RechartsのResponsiveContainerがレンダリングされる
+    const container = document.querySelector('.recharts-responsive-container');
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/CategoryPieChart/CategoryPieChart.tsx
+++ b/src/components/charts/CategoryPieChart/CategoryPieChart.tsx
@@ -1,0 +1,38 @@
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
+import { useCategorySummary } from '@/hooks';
+import { ChartContainer } from '../ChartContainer';
+
+/**
+ * カテゴリ別支出の円グラフ
+ */
+export function CategoryPieChart() {
+  const data = useCategorySummary();
+
+  return (
+    <ChartContainer title="カテゴリ別支出" height={400}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="amount"
+            nameKey="category"
+            cx="50%"
+            cy="50%"
+            outerRadius={120}
+            label={({ category, percentage }) => `${category} ${(percentage * 100).toFixed(0)}%`}
+            labelLine={false}
+          >
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.color} />
+            ))}
+          </Pie>
+          <Tooltip
+            formatter={(value: number) => `¥${value.toLocaleString()}`}
+            contentStyle={{ borderRadius: 8 }}
+          />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/CategoryPieChart/index.ts
+++ b/src/components/charts/CategoryPieChart/index.ts
@@ -1,0 +1,1 @@
+export { CategoryPieChart } from './CategoryPieChart';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -1,2 +1,3 @@
 export { ChartContainer } from './ChartContainer';
 export { MonthlyTrendChart } from './MonthlyTrendChart';
+export { CategoryPieChart } from './CategoryPieChart';


### PR DESCRIPTION
## Summary
- カテゴリ別支出の円グラフコンポーネントを追加
- useCategorySummaryフックを使用してデータを取得
- RechartsのPieChart/Pie/Cell/Tooltip/Legendを使用

## Test plan
- [x] タイトルが「カテゴリ別支出」と表示される
- [x] ChartContainerでラップされている
- [x] ResponsiveContainerがレンダリングされる

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)