### PR TITLE
feat(charts): CategoryBarChartコンポーネントを追加 #37

### DIFF
--- a/src/components/charts/CategoryBarChart/CategoryBarChart.test.tsx
+++ b/src/components/charts/CategoryBarChart/CategoryBarChart.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CategoryBarChart } from './CategoryBarChart';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+// ResizeObserverのモック
+beforeEach(() => {
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食費',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '日用品',
+    amount: -10000,
+    institution: 'テスト銀行',
+    category: '日用品',
+    subcategory: '雑貨',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('CategoryBarChart', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイトルを表示する', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<CategoryBarChart />, { wrapper });
+
+    expect(screen.getByText('カテゴリ別支出（棒グラフ）')).toBeInTheDocument();
+  });
+
+  it('ChartContainerでラップされている', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { container } = render(<CategoryBarChart />, { wrapper });
+
+    // ChartContainerのCardが存在する
+    expect(container.querySelector('[class*="rounded"]')).toBeInTheDocument();
+  });
+
+  it('RechartsのResponsiveContainerがレンダリングされる', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<CategoryBarChart />, { wrapper });
+
+    // RechartsのResponsiveContainerがレンダリングされる
+    const container = document.querySelector('.recharts-responsive-container');
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/CategoryBarChart/CategoryBarChart.tsx
+++ b/src/components/charts/CategoryBarChart/CategoryBarChart.tsx
@@ -1,0 +1,44 @@
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from 'recharts';
+import { useCategorySummary } from '@/hooks';
+import { ChartContainer } from '../ChartContainer';
+
+/**
+ * カテゴリ別支出の横棒グラフ
+ */
+export function CategoryBarChart() {
+  const data = useCategorySummary();
+
+  return (
+    <ChartContainer title="カテゴリ別支出（棒グラフ）" height={400}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} layout="vertical" margin={{ left: 80 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#E5E1D8" />
+          <XAxis
+            type="number"
+            tick={{ fontSize: 12 }}
+            tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`}
+          />
+          <YAxis type="category" dataKey="category" tick={{ fontSize: 12 }} width={80} />
+          <Tooltip
+            formatter={(value: number) => `¥${value.toLocaleString()}`}
+            contentStyle={{ borderRadius: 8 }}
+          />
+          <Bar dataKey="amount" name="支出">
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.color} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/CategoryBarChart/index.ts
+++ b/src/components/charts/CategoryBarChart/index.ts
@@ -1,0 +1,1 @@
+export { CategoryBarChart } from './CategoryBarChart';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -1,3 +1,4 @@
 export { ChartContainer } from './ChartContainer';
 export { MonthlyTrendChart } from './MonthlyTrendChart';
 export { CategoryPieChart } from './CategoryPieChart';
+export { CategoryBarChart } from './CategoryBarChart';


### PR DESCRIPTION
## Summary
- カテゴリ別支出の横棒グラフコンポーネントを追加
- useCategorySummaryフックでデータ取得
- RechartsのBarChart（layout=vertical）を使用

## Test plan
- [x] タイトルが「カテゴリ別支出（棒グラフ）」と表示される
- [x] ChartContainerでラップされている
- [x] ResponsiveContainerがレンダリングされる

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)