### PR TITLE
feat(charts): SubcategoryChartコンポーネントを追加 #38

### DIFF
--- a/src/components/charts/SubcategoryChart/SubcategoryChart.test.tsx
+++ b/src/components/charts/SubcategoryChart/SubcategoryChart.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SubcategoryChart } from './SubcategoryChart';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+// ResizeObserverのモック
+beforeEach(() => {
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食料品',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '外食',
+    amount: -10000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '外食',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-3',
+    date: new Date('2025-01-25'),
+    description: '雑貨',
+    amount: -5000,
+    institution: 'テスト銀行',
+    category: '日用品',
+    subcategory: '雑貨',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('SubcategoryChart', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('カテゴリ名を含むタイトルを表示する', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<SubcategoryChart category="食費" />, { wrapper });
+
+    expect(screen.getByText('食費の内訳')).toBeInTheDocument();
+  });
+
+  it('ChartContainerでラップされている', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { container } = render(<SubcategoryChart category="食費" />, { wrapper });
+
+    expect(container.querySelector('[class*="rounded"]')).toBeInTheDocument();
+  });
+
+  it('RechartsのResponsiveContainerがレンダリングされる', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<SubcategoryChart category="食費" />, { wrapper });
+
+    const container = document.querySelector('.recharts-responsive-container');
+    expect(container).toBeInTheDocument();
+  });
+
+  it('戻るボタンをクリックするとonBackが呼ばれる', async () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+
+    render(<SubcategoryChart category="食費" onBack={onBack} />, { wrapper });
+
+    await user.click(screen.getByText('← 戻る'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('onBackがない場合は戻るボタンが表示されない', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<SubcategoryChart category="食費" />, { wrapper });
+
+    expect(screen.queryByText('← 戻る')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/charts/SubcategoryChart/SubcategoryChart.tsx
+++ b/src/components/charts/SubcategoryChart/SubcategoryChart.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import { useFilteredData } from '@/hooks';
+import { ChartContainer } from '../ChartContainer';
+import { getCategoryColor } from '@/constants';
+
+type SubcategoryChartProps = {
+  category: string;
+  onBack?: () => void;
+};
+
+/**
+ * 中項目ドリルダウンチャート
+ * カテゴリ内の中項目内訳を横棒グラフで表示
+ */
+export function SubcategoryChart({ category, onBack }: SubcategoryChartProps) {
+  const { data } = useFilteredData();
+
+  // カテゴリ内の中項目を集計
+  const subcategoryData = useMemo(() => {
+    const filtered = data.filter((t) => t.category === category && t.amount < 0);
+    const bySubcategory = new Map<string, number>();
+
+    for (const t of filtered) {
+      const current = bySubcategory.get(t.subcategory) ?? 0;
+      bySubcategory.set(t.subcategory, current + Math.abs(t.amount));
+    }
+
+    return Array.from(bySubcategory.entries())
+      .map(([subcategory, amount]) => ({ subcategory, amount }))
+      .sort((a, b) => b.amount - a.amount);
+  }, [data, category]);
+
+  const color = getCategoryColor(category);
+
+  return (
+    <ChartContainer title={`${category}の内訳`} height={300}>
+      {onBack && (
+        <button onClick={onBack} className="text-sm text-primary hover:underline mb-2">
+          ← 戻る
+        </button>
+      )}
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={subcategoryData} layout="vertical" margin={{ left: 100 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#E5E1D8" />
+          <XAxis
+            type="number"
+            tick={{ fontSize: 12 }}
+            tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`}
+          />
+          <YAxis type="category" dataKey="subcategory" tick={{ fontSize: 12 }} width={100} />
+          <Tooltip
+            formatter={(value: number) => `¥${value.toLocaleString()}`}
+            contentStyle={{ borderRadius: 8 }}
+          />
+          <Bar dataKey="amount" name="支出" fill={color} />
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/SubcategoryChart/index.ts
+++ b/src/components/charts/SubcategoryChart/index.ts
@@ -1,0 +1,1 @@
+export { SubcategoryChart } from './SubcategoryChart';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -2,3 +2,4 @@ export { ChartContainer } from './ChartContainer';
 export { MonthlyTrendChart } from './MonthlyTrendChart';
 export { CategoryPieChart } from './CategoryPieChart';
 export { CategoryBarChart } from './CategoryBarChart';
+export { SubcategoryChart } from './SubcategoryChart';


### PR DESCRIPTION
## Summary
- 中項目ドリルダウンチャートコンポーネントを追加
- カテゴリ内の中項目内訳を横棒グラフで表示
- 戻るボタンでonBackコールバックを呼び出し

## Test plan
- [x] カテゴリ名を含むタイトルが表示される
- [x] ChartContainerでラップされている
- [x] ResponsiveContainerがレンダリングされる
- [x] 戻るボタンクリックでonBackが呼ばれる
- [x] onBackがない場合は戻るボタンが表示されない

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)