### PR TITLE
feat(charts): InstitutionChartコンポーネントを追加 #39

### DIFF
--- a/src/components/charts/InstitutionChart/InstitutionChart.test.tsx
+++ b/src/components/charts/InstitutionChart/InstitutionChart.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { InstitutionChart } from './InstitutionChart';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+// ResizeObserverのモック
+beforeEach(() => {
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食費',
+    amount: -30000,
+    institution: '三菱UFJ銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '日用品',
+    amount: -10000,
+    institution: '楽天カード',
+    category: '日用品',
+    subcategory: '雑貨',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('InstitutionChart', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイトルを表示する', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<InstitutionChart />, { wrapper });
+
+    expect(screen.getByText('金融機関別支出')).toBeInTheDocument();
+  });
+
+  it('ChartContainerでラップされている', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { container } = render(<InstitutionChart />, { wrapper });
+
+    expect(container.querySelector('[class*="rounded"]')).toBeInTheDocument();
+  });
+
+  it('RechartsのResponsiveContainerがレンダリングされる', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<InstitutionChart />, { wrapper });
+
+    const container = document.querySelector('.recharts-responsive-container');
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/InstitutionChart/InstitutionChart.tsx
+++ b/src/components/charts/InstitutionChart/InstitutionChart.tsx
@@ -1,0 +1,51 @@
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from 'recharts';
+import { useInstitutionSummary } from '@/hooks';
+import { ChartContainer } from '../ChartContainer';
+import { CATEGORIES } from '@/constants';
+
+// カテゴリ色の配列を生成
+const INSTITUTION_COLORS = Object.values(CATEGORIES).map((c) => c.color);
+
+/**
+ * 金融機関別支出チャート
+ */
+export function InstitutionChart() {
+  const data = useInstitutionSummary();
+
+  return (
+    <ChartContainer title="金融機関別支出" height={400}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} layout="vertical" margin={{ left: 120 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#E5E1D8" />
+          <XAxis
+            type="number"
+            tick={{ fontSize: 12 }}
+            tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`}
+          />
+          <YAxis type="category" dataKey="institution" tick={{ fontSize: 11 }} width={120} />
+          <Tooltip
+            formatter={(value: number) => `¥${value.toLocaleString()}`}
+            contentStyle={{ borderRadius: 8 }}
+          />
+          <Bar dataKey="amount" name="支出">
+            {data.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={INSTITUTION_COLORS[index % INSTITUTION_COLORS.length]}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/InstitutionChart/index.ts
+++ b/src/components/charts/InstitutionChart/index.ts
@@ -1,0 +1,1 @@
+export { InstitutionChart } from './InstitutionChart';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -3,3 +3,4 @@ export { MonthlyTrendChart } from './MonthlyTrendChart';
 export { CategoryPieChart } from './CategoryPieChart';
 export { CategoryBarChart } from './CategoryBarChart';
 export { SubcategoryChart } from './SubcategoryChart';
+export { InstitutionChart } from './InstitutionChart';


### PR DESCRIPTION
## Summary
- 金融機関別支出の横棒グラフコンポーネントを追加
- useInstitutionSummaryフックでデータ取得
- カテゴリ色配列を循環使用

## Test plan
- [x] タイトルが「金融機関別支出」と表示される
- [x] ChartContainerでラップされている
- [x] ResponsiveContainerがレンダリングされる

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)