### PR TITLE
feat(charts): IncomeChartコンポーネントを追加 #40

### DIFF
--- a/src/components/charts/IncomeChart/IncomeChart.test.tsx
+++ b/src/components/charts/IncomeChart/IncomeChart.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IncomeChart } from './IncomeChart';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+// ResizeObserverのモック
+beforeEach(() => {
+  global.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+});
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '給与',
+    amount: 300000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: 'ポイント',
+    amount: 5000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: 'ポイント',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('IncomeChart', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイトルを表示する', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<IncomeChart />, { wrapper });
+
+    expect(screen.getByText('収入源の内訳')).toBeInTheDocument();
+  });
+
+  it('ChartContainerでラップされている', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { container } = render(<IncomeChart />, { wrapper });
+
+    expect(container.querySelector('[class*="rounded"]')).toBeInTheDocument();
+  });
+
+  it('RechartsのResponsiveContainerがレンダリングされる', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<IncomeChart />, { wrapper });
+
+    const container = document.querySelector('.recharts-responsive-container');
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/IncomeChart/IncomeChart.tsx
+++ b/src/components/charts/IncomeChart/IncomeChart.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
+import { useFilteredData } from '@/hooks';
+import { ChartContainer } from '../ChartContainer';
+import { CATEGORIES } from '@/constants';
+
+// 収入用カラーパレット（緑系を中心に）
+const INCOME_COLORS = [
+  '#059669', // 収入色
+  '#10B981',
+  '#34D399',
+  '#6EE7B7',
+  '#A7F3D0',
+  ...Object.values(CATEGORIES).map((c) => c.color),
+];
+
+/**
+ * 収入源内訳の円グラフ
+ */
+export function IncomeChart() {
+  const { data } = useFilteredData();
+
+  const incomeData = useMemo(() => {
+    const incomes = data.filter((t) => t.amount > 0);
+    const bySubcategory = new Map<string, number>();
+
+    for (const t of incomes) {
+      const current = bySubcategory.get(t.subcategory) ?? 0;
+      bySubcategory.set(t.subcategory, current + t.amount);
+    }
+
+    const total = incomes.reduce((sum, t) => sum + t.amount, 0);
+
+    return Array.from(bySubcategory.entries())
+      .map(([subcategory, amount]) => ({
+        subcategory,
+        amount,
+        percentage: total > 0 ? amount / total : 0,
+      }))
+      .sort((a, b) => b.amount - a.amount);
+  }, [data]);
+
+  return (
+    <ChartContainer title="収入源の内訳" height={400}>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Pie
+            data={incomeData}
+            dataKey="amount"
+            nameKey="subcategory"
+            cx="50%"
+            cy="50%"
+            outerRadius={120}
+            label={({ subcategory, percentage }) =>
+              `${subcategory} (${(percentage * 100).toFixed(1)}%)`
+            }
+            labelLine={false}
+          >
+            {incomeData.map((_, index) => (
+              <Cell key={`cell-${index}`} fill={INCOME_COLORS[index % INCOME_COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip
+            formatter={(value: number) => `¥${value.toLocaleString()}`}
+            contentStyle={{ borderRadius: 8 }}
+          />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/IncomeChart/index.ts
+++ b/src/components/charts/IncomeChart/index.ts
@@ -1,0 +1,1 @@
+export { IncomeChart } from './IncomeChart';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -4,3 +4,4 @@ export { CategoryPieChart } from './CategoryPieChart';
 export { CategoryBarChart } from './CategoryBarChart';
 export { SubcategoryChart } from './SubcategoryChart';
 export { InstitutionChart } from './InstitutionChart';
+export { IncomeChart } from './IncomeChart';


### PR DESCRIPTION
## Summary
- 収入源内訳の円グラフコンポーネントを追加
- 収入を中項目別に集計して表示
- パーセンテージをラベル表示

## Test plan
- [x] タイトルが「収入源の内訳」と表示される
- [x] ChartContainerでラップされている
- [x] ResponsiveContainerがレンダリングされる

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)