### PR TITLE
feat(charts): HeatmapChartコンポーネントを追加 #41

### DIFF
--- a/src/components/charts/HeatmapChart/HeatmapChart.test.tsx
+++ b/src/components/charts/HeatmapChart/HeatmapChart.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HeatmapChart } from './HeatmapChart';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食費',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-02-20'),
+    description: '日用品',
+    amount: -10000,
+    institution: 'テスト銀行',
+    category: '日用品',
+    subcategory: '雑貨',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('HeatmapChart', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイトルを表示する', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<HeatmapChart />, { wrapper });
+
+    expect(screen.getByText('月別×カテゴリ ヒートマップ')).toBeInTheDocument();
+  });
+
+  it('ChartContainerでラップされている', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    const { container } = render(<HeatmapChart />, { wrapper });
+
+    expect(container.querySelector('[class*="rounded"]')).toBeInTheDocument();
+  });
+
+  it('テーブルがレンダリングされる', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<HeatmapChart />, { wrapper });
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('カテゴリヘッダーが表示される', () => {
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+
+    render(<HeatmapChart />, { wrapper });
+
+    expect(screen.getByText('カテゴリ')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/HeatmapChart/HeatmapChart.tsx
+++ b/src/components/charts/HeatmapChart/HeatmapChart.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+import { useFilteredData } from '@/hooks';
+import { ChartContainer } from '../ChartContainer';
+import { formatCurrency } from '@/utils/formatters';
+import { getCategoryColor } from '@/constants';
+
+/**
+ * 月×カテゴリのヒートマップチャート
+ */
+export function HeatmapChart() {
+  const { data } = useFilteredData();
+
+  const { months, categories, heatmapData, maxValue } = useMemo(() => {
+    const expenses = data.filter((t) => t.amount < 0);
+
+    // 月とカテゴリを抽出
+    const monthSet = new Set<string>();
+    const categorySet = new Set<string>();
+    const valueMap = new Map<string, number>();
+
+    for (const t of expenses) {
+      const month = `${t.date.getMonth() + 1}月`;
+      monthSet.add(month);
+      categorySet.add(t.category);
+
+      const key = `${month}-${t.category}`;
+      const current = valueMap.get(key) ?? 0;
+      valueMap.set(key, current + Math.abs(t.amount));
+    }
+
+    const months = Array.from(monthSet).sort((a, b) => parseInt(a) - parseInt(b));
+    const categories = Array.from(categorySet);
+    const maxValue = Math.max(...valueMap.values(), 1);
+
+    return { months, categories, heatmapData: valueMap, maxValue };
+  }, [data]);
+
+  const getOpacity = (value: number) => {
+    return 0.2 + (value / maxValue) * 0.8;
+  };
+
+  return (
+    <ChartContainer title="月別×カテゴリ ヒートマップ" height={500}>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="p-2 text-left">カテゴリ</th>
+              {months.map((month) => (
+                <th key={month} className="p-2 text-center">
+                  {month}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {categories.map((category) => (
+              <tr key={category}>
+                <td className="p-2 font-medium">{category}</td>
+                {months.map((month) => {
+                  const key = `${month}-${category}`;
+                  const value = heatmapData.get(key) ?? 0;
+                  const color = getCategoryColor(category);
+
+                  return (
+                    <td
+                      key={month}
+                      className="p-2 text-center text-xs"
+                      style={{
+                        backgroundColor: value > 0 ? color : 'transparent',
+                        opacity: value > 0 ? getOpacity(value) : 1,
+                        color: value > 0 ? 'white' : 'inherit',
+                      }}
+                      title={formatCurrency(-value)}
+                    >
+                      {value > 0 ? `¥${(value / 1000).toFixed(0)}K` : '-'}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/HeatmapChart/index.ts
+++ b/src/components/charts/HeatmapChart/index.ts
@@ -1,0 +1,1 @@
+export { HeatmapChart } from './HeatmapChart';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -5,3 +5,4 @@ export { CategoryBarChart } from './CategoryBarChart';
 export { SubcategoryChart } from './SubcategoryChart';
 export { InstitutionChart } from './InstitutionChart';
 export { IncomeChart } from './IncomeChart';
+export { HeatmapChart } from './HeatmapChart';


### PR DESCRIPTION
## Summary
- 月×カテゴリのヒートマップチャートを追加
- HTMLテーブルでマトリクス表示
- 金額に応じた濃淡を適用

## Test plan
- [x] タイトルが「月別×カテゴリ ヒートマップ」と表示される
- [x] ChartContainerでラップされている
- [x] テーブルがレンダリングされる
- [x] カテゴリヘッダーが表示される

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)