### PR TITLE
feat(dashboard): SummaryCardsコンポーネントを追加 #42

### DIFF
--- a/src/components/dashboard/SummaryCards/BalanceCard.tsx
+++ b/src/components/dashboard/SummaryCards/BalanceCard.tsx
@@ -1,0 +1,23 @@
+import { Card, Amount, TrendIndicator } from '@/components/ui';
+import { useFilteredData, useTrend } from '@/hooks';
+import { calcIncome, calcExpense } from '@/utils/calculations';
+
+/**
+ * 収支バランスサマリーカード
+ */
+export function BalanceCard() {
+  const { data } = useFilteredData();
+  const trend = useTrend();
+  const income = calcIncome(data);
+  const expense = calcExpense(data);
+  const balance = income - expense;
+
+  return (
+    <Card title="収支バランス" accentColor="primary">
+      <Amount value={balance} size="lg" />
+      <div className="mt-2">
+        <TrendIndicator value={trend.balance} positiveIsGood />
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/SummaryCards/ExpenseCard.tsx
+++ b/src/components/dashboard/SummaryCards/ExpenseCard.tsx
@@ -1,0 +1,21 @@
+import { Card, Amount, TrendIndicator } from '@/components/ui';
+import { useFilteredData, useTrend } from '@/hooks';
+import { calcExpense } from '@/utils/calculations';
+
+/**
+ * 支出サマリーカード
+ */
+export function ExpenseCard() {
+  const { data } = useFilteredData();
+  const trend = useTrend();
+  const expense = calcExpense(data);
+
+  return (
+    <Card title="月間支出" accentColor="expense">
+      <Amount value={-expense} size="lg" />
+      <div className="mt-2">
+        <TrendIndicator value={trend.expense} positiveIsGood={false} />
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/SummaryCards/IncomeCard.tsx
+++ b/src/components/dashboard/SummaryCards/IncomeCard.tsx
@@ -1,0 +1,21 @@
+import { Card, Amount, TrendIndicator } from '@/components/ui';
+import { useFilteredData, useTrend } from '@/hooks';
+import { calcIncome } from '@/utils/calculations';
+
+/**
+ * 収入サマリーカード
+ */
+export function IncomeCard() {
+  const { data } = useFilteredData();
+  const trend = useTrend();
+  const income = calcIncome(data);
+
+  return (
+    <Card title="月間収入" accentColor="income">
+      <Amount value={income} size="lg" />
+      <div className="mt-2">
+        <TrendIndicator value={trend.income} positiveIsGood />
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/SummaryCards/SummaryCards.test.tsx
+++ b/src/components/dashboard/SummaryCards/SummaryCards.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SummaryCards } from './SummaryCards';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '給与',
+    amount: 300000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-20'),
+    description: '食費',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('SummaryCards', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+  });
+
+  it('収入カードを表示する', () => {
+    render(<SummaryCards />, { wrapper });
+    expect(screen.getByText('月間収入')).toBeInTheDocument();
+  });
+
+  it('支出カードを表示する', () => {
+    render(<SummaryCards />, { wrapper });
+    expect(screen.getByText('月間支出')).toBeInTheDocument();
+  });
+
+  it('収支カードを表示する', () => {
+    render(<SummaryCards />, { wrapper });
+    expect(screen.getByText('収支バランス')).toBeInTheDocument();
+  });
+
+  it('3つのカードがグリッドでレイアウトされる', () => {
+    const { container } = render(<SummaryCards />, { wrapper });
+    const grid = container.querySelector('.grid');
+    expect(grid).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/SummaryCards/SummaryCards.tsx
+++ b/src/components/dashboard/SummaryCards/SummaryCards.tsx
@@ -1,0 +1,17 @@
+import { IncomeCard } from './IncomeCard';
+import { ExpenseCard } from './ExpenseCard';
+import { BalanceCard } from './BalanceCard';
+
+/**
+ * サマリーカード群
+ * 収入・支出・収支の3枚のカードを表示
+ */
+export function SummaryCards() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <IncomeCard />
+      <ExpenseCard />
+      <BalanceCard />
+    </div>
+  );
+}

--- a/src/components/dashboard/SummaryCards/index.ts
+++ b/src/components/dashboard/SummaryCards/index.ts
@@ -1,0 +1,4 @@
+export { SummaryCards } from './SummaryCards';
+export { IncomeCard } from './IncomeCard';
+export { ExpenseCard } from './ExpenseCard';
+export { BalanceCard } from './BalanceCard';

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { SummaryCards, IncomeCard, ExpenseCard, BalanceCard } from './SummaryCards';


### PR DESCRIPTION
## Summary
- サマリーカード群コンポーネントを追加
- IncomeCard, ExpenseCard, BalanceCardの3枚
- TrendIndicatorで前月比を表示
- アクセントボーダーで色分け

## Test plan
- [x] 収入カードが表示される
- [x] 支出カードが表示される
- [x] 収支カードが表示される
- [x] 3つのカードがグリッドでレイアウトされる

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)