### PR TITLE
feat(FilterPanel): フィルターパネルコンポーネント実装 #43

### DIFF
--- a/src/components/dashboard/FilterPanel/CategoryFilter.tsx
+++ b/src/components/dashboard/FilterPanel/CategoryFilter.tsx
@@ -1,0 +1,31 @@
+import { Select } from '@/components/ui';
+import { useFilterContext, useTransactionContext } from '@/contexts';
+import { useMemo } from 'react';
+
+/**
+ * カテゴリフィルター
+ */
+export function CategoryFilter() {
+  const { filters, updateFilter } = useFilterContext();
+  const { transactions } = useTransactionContext();
+
+  // トランザクションからカテゴリ一覧を抽出
+  const categories = useMemo(() => {
+    const categorySet = new Set(transactions.map((t) => t.category));
+    return Array.from(categorySet).sort();
+  }, [transactions]);
+
+  const options = [
+    { value: 'all', label: 'すべて' },
+    ...categories.map((c) => ({ value: c, label: c })),
+  ];
+
+  return (
+    <Select
+      label="カテゴリ"
+      value={filters.category}
+      options={options}
+      onChange={(e) => updateFilter('category', e.target.value)}
+    />
+  );
+}

--- a/src/components/dashboard/FilterPanel/FilterPanel.test.tsx
+++ b/src/components/dashboard/FilterPanel/FilterPanel.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FilterPanel } from './FilterPanel';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '給与',
+    amount: 300000,
+    institution: 'テスト銀行',
+    category: '収入',
+    subcategory: '給与',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('FilterPanel', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+  });
+
+  it('年フィルターが表示される', () => {
+    render(<FilterPanel />, { wrapper });
+    expect(screen.getByText('年')).toBeInTheDocument();
+  });
+
+  it('月フィルターが表示される', () => {
+    render(<FilterPanel />, { wrapper });
+    expect(screen.getByText('月')).toBeInTheDocument();
+  });
+
+  it('カテゴリフィルターが表示される', () => {
+    render(<FilterPanel />, { wrapper });
+    expect(screen.getByText('カテゴリ')).toBeInTheDocument();
+  });
+
+  it('金融機関フィルターが表示される', () => {
+    render(<FilterPanel />, { wrapper });
+    expect(screen.getByText('金融機関')).toBeInTheDocument();
+  });
+
+  it('検索入力が表示される', () => {
+    render(<FilterPanel />, { wrapper });
+    expect(screen.getByPlaceholderText('内容を検索...')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/FilterPanel/FilterPanel.tsx
+++ b/src/components/dashboard/FilterPanel/FilterPanel.tsx
@@ -1,0 +1,28 @@
+import { PeriodFilter } from './PeriodFilter';
+import { CategoryFilter } from './CategoryFilter';
+import { InstitutionFilter } from './InstitutionFilter';
+import { SearchInput } from '@/components/ui';
+import { useFilterContext } from '@/contexts';
+
+/**
+ * フィルターパネル
+ * 期間・カテゴリ・金融機関・検索のフィルターを表示
+ */
+export function FilterPanel() {
+  const { filters, updateFilter } = useFilterContext();
+
+  return (
+    <div className="bg-surface rounded-lg shadow-md p-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <PeriodFilter />
+        <CategoryFilter />
+        <InstitutionFilter />
+        <SearchInput
+          value={filters.searchQuery}
+          onChange={(value) => updateFilter('searchQuery', value)}
+          placeholder="内容を検索..."
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/FilterPanel/InstitutionFilter.tsx
+++ b/src/components/dashboard/FilterPanel/InstitutionFilter.tsx
@@ -1,0 +1,31 @@
+import { Select } from '@/components/ui';
+import { useFilterContext, useTransactionContext } from '@/contexts';
+import { useMemo } from 'react';
+
+/**
+ * 金融機関フィルター
+ */
+export function InstitutionFilter() {
+  const { filters, updateFilter } = useFilterContext();
+  const { transactions } = useTransactionContext();
+
+  // トランザクションから金融機関一覧を抽出
+  const institutions = useMemo(() => {
+    const institutionSet = new Set(transactions.map((t) => t.institution));
+    return Array.from(institutionSet).sort();
+  }, [transactions]);
+
+  const options = [
+    { value: 'all', label: 'すべて' },
+    ...institutions.map((i) => ({ value: i, label: i })),
+  ];
+
+  return (
+    <Select
+      label="金融機関"
+      value={filters.institution}
+      options={options}
+      onChange={(e) => updateFilter('institution', e.target.value)}
+    />
+  );
+}

--- a/src/components/dashboard/FilterPanel/PeriodFilter.tsx
+++ b/src/components/dashboard/FilterPanel/PeriodFilter.tsx
@@ -1,0 +1,38 @@
+import { Select } from '@/components/ui';
+import { useFilterContext } from '@/contexts';
+
+const YEARS = [2025, 2024, 2023];
+const MONTHS = [
+  { value: 'all', label: '全期間' },
+  ...Array.from({ length: 12 }, (_, i) => ({
+    value: String(i + 1),
+    label: `${i + 1}月`,
+  })),
+];
+
+/**
+ * 期間フィルター（年・月）
+ */
+export function PeriodFilter() {
+  const { filters, updateFilter } = useFilterContext();
+
+  return (
+    <div className="flex gap-2">
+      <Select
+        label="年"
+        value={String(filters.year)}
+        options={YEARS.map((y) => ({ value: String(y), label: `${y}年` }))}
+        onChange={(e) => updateFilter('year', Number(e.target.value))}
+      />
+      <Select
+        label="月"
+        value={filters.month === 'all' ? 'all' : String(filters.month)}
+        options={MONTHS}
+        onChange={(e) => {
+          const value = e.target.value;
+          updateFilter('month', value === 'all' ? 'all' : Number(value));
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/dashboard/FilterPanel/index.ts
+++ b/src/components/dashboard/FilterPanel/index.ts
@@ -1,0 +1,4 @@
+export { FilterPanel } from './FilterPanel';
+export { PeriodFilter } from './PeriodFilter';
+export { CategoryFilter } from './CategoryFilter';
+export { InstitutionFilter } from './InstitutionFilter';

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,1 +1,2 @@
 export { SummaryCards, IncomeCard, ExpenseCard, BalanceCard } from './SummaryCards';
+export { FilterPanel, PeriodFilter, CategoryFilter, InstitutionFilter } from './FilterPanel';


### PR DESCRIPTION
## 概要
Issue #43 のフィルターパネルコンポーネントを実装

## 変更内容
- `PeriodFilter`: 年・月選択ドロップダウン
- `CategoryFilter`: カテゴリ選択（トランザクションから動的取得）
- `InstitutionFilter`: 金融機関選択（トランザクションから動的取得）
- `FilterPanel`: 全フィルター + SearchInputを統合したパネル

## テスト
- 5件のテストを追加
- 全427テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)