### PR TITLE
feat(TransactionTable): 明細テーブルコンポーネント実装 #44

### DIFF
--- a/src/components/dashboard/TransactionTable/TablePagination.tsx
+++ b/src/components/dashboard/TransactionTable/TablePagination.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@/components/ui';
+
+type TablePaginationProps = {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+};
+
+export function TablePagination({ page, totalPages, onPageChange }: TablePaginationProps) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-t border-border">
+      <span className="text-sm text-text-secondary">
+        ページ {page + 1} / {totalPages}
+      </span>
+      <div className="flex gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page === 0}
+        >
+          前へ
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page >= totalPages - 1}
+        >
+          次へ
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/TransactionTable/TransactionTable.test.tsx
+++ b/src/components/dashboard/TransactionTable/TransactionTable.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TransactionTable } from './TransactionTable';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = Array.from({ length: 25 }, (_, i) => ({
+  id: `test-${i + 1}`,
+  date: new Date(`2025-01-${String(i + 1).padStart(2, '0')}`),
+  description: `テスト取引${i + 1}`,
+  amount: i % 2 === 0 ? -(i + 1) * 100 : (i + 1) * 1000,
+  institution: 'テスト銀行',
+  category: '食費',
+  subcategory: '食料品',
+  memo: '',
+  isTransfer: false,
+  isCalculated: true,
+}));
+
+describe('TransactionTable', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+  });
+
+  it('テーブルヘッダーが表示される', async () => {
+    render(<TransactionTable />, { wrapper });
+    expect(await screen.findByText(/日付/)).toBeInTheDocument();
+    expect(screen.getByText('内容')).toBeInTheDocument();
+    expect(screen.getByText('カテゴリ')).toBeInTheDocument();
+    expect(screen.getByText('金融機関')).toBeInTheDocument();
+    expect(screen.getByText(/金額/)).toBeInTheDocument();
+  });
+
+  it('取引明細が表示される', async () => {
+    render(<TransactionTable />, { wrapper });
+    // デフォルトは日付降順なのでテスト取引25が最初
+    expect(await screen.findByText('テスト取引25')).toBeInTheDocument();
+  });
+
+  it('ページネーションが表示される', async () => {
+    render(<TransactionTable />, { wrapper });
+    await screen.findByText('テスト取引25');
+    expect(screen.getByRole('button', { name: '次へ' })).toBeInTheDocument();
+  });
+
+  it('次ページボタンで次のページが表示される', async () => {
+    const user = userEvent.setup();
+    render(<TransactionTable />, { wrapper });
+    await screen.findByText('テスト取引25');
+
+    const nextButton = screen.getByRole('button', { name: '次へ' });
+    await user.click(nextButton);
+
+    // 2ページ目にはテスト取引5～1が表示される
+    expect(await screen.findByText('テスト取引5')).toBeInTheDocument();
+  });
+
+  it('日付ヘッダークリックでソート順が変わる', async () => {
+    const user = userEvent.setup();
+    render(<TransactionTable />, { wrapper });
+    await screen.findByText('テスト取引25');
+
+    const dateHeader = screen.getByText(/日付/);
+    await user.click(dateHeader);
+
+    // ソート順が変更される（デフォルトはdesc、クリックでasc）
+    // asc順になるとテスト取引1が最初に表示される
+    expect(await screen.findByText('テスト取引1')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/TransactionTable/TransactionTable.tsx
+++ b/src/components/dashboard/TransactionTable/TransactionTable.tsx
@@ -1,0 +1,81 @@
+import { useState, useMemo } from 'react';
+import { Table, TableHeader, TableRow, TableCell, Amount } from '@/components/ui';
+import { useFilteredData } from '@/hooks';
+import { formatDate } from '@/utils/formatters';
+import { TablePagination } from './TablePagination';
+import type { SortState } from '@/types';
+
+const PAGE_SIZE = 20;
+
+export function TransactionTable() {
+  const { data, filteredCount } = useFilteredData();
+  const [page, setPage] = useState(0);
+  const [sort, setSort] = useState<SortState>({ column: 'date', direction: 'desc' });
+
+  const sortedData = useMemo(() => {
+    return [...data].sort((a, b) => {
+      const multiplier = sort.direction === 'asc' ? 1 : -1;
+      if (sort.column === 'date') {
+        return multiplier * (a.date.getTime() - b.date.getTime());
+      }
+      if (sort.column === 'amount') {
+        return multiplier * (a.amount - b.amount);
+      }
+      return 0;
+    });
+  }, [data, sort]);
+
+  const paginatedData = sortedData.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(filteredCount / PAGE_SIZE));
+
+  const handleSort = (column: SortState['column']) => {
+    setSort((prev) => ({
+      column,
+      direction: prev.column === column && prev.direction === 'desc' ? 'asc' : 'desc',
+    }));
+    setPage(0);
+  };
+
+  return (
+    <div className="bg-surface rounded-lg shadow-md overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableCell
+            header
+            onClick={() => handleSort('date')}
+            className="cursor-pointer hover:bg-border/20"
+          >
+            日付 {sort.column === 'date' && (sort.direction === 'asc' ? '▲' : '▼')}
+          </TableCell>
+          <TableCell header>内容</TableCell>
+          <TableCell header>カテゴリ</TableCell>
+          <TableCell header>金融機関</TableCell>
+          <TableCell
+            header
+            align="right"
+            onClick={() => handleSort('amount')}
+            className="cursor-pointer hover:bg-border/20"
+          >
+            金額 {sort.column === 'amount' && (sort.direction === 'asc' ? '▲' : '▼')}
+          </TableCell>
+        </TableHeader>
+        <tbody>
+          {paginatedData.map((t) => (
+            <TableRow key={t.id}>
+              <TableCell>{formatDate(t.date)}</TableCell>
+              <TableCell>{t.description}</TableCell>
+              <TableCell>
+                {t.category} / {t.subcategory}
+              </TableCell>
+              <TableCell>{t.institution}</TableCell>
+              <TableCell align="right">
+                <Amount value={t.amount} size="sm" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </tbody>
+      </Table>
+      <TablePagination page={page} totalPages={totalPages} onPageChange={setPage} />
+    </div>
+  );
+}

--- a/src/components/dashboard/TransactionTable/index.ts
+++ b/src/components/dashboard/TransactionTable/index.ts
@@ -1,0 +1,2 @@
+export { TransactionTable } from './TransactionTable';
+export { TablePagination } from './TablePagination';

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,2 +1,3 @@
 export { SummaryCards, IncomeCard, ExpenseCard, BalanceCard } from './SummaryCards';
 export { FilterPanel, PeriodFilter, CategoryFilter, InstitutionFilter } from './FilterPanel';
+export { TransactionTable, TablePagination } from './TransactionTable';

--- a/src/components/ui/Table/TableCell.tsx
+++ b/src/components/ui/Table/TableCell.tsx
@@ -4,9 +4,17 @@ type TableCellProps = {
   children: React.ReactNode;
   header?: boolean;
   align?: 'left' | 'center' | 'right';
+  onClick?: () => void;
+  className?: string;
 };
 
-export function TableCell({ children, header = false, align = 'left' }: TableCellProps) {
+export function TableCell({
+  children,
+  header = false,
+  align = 'left',
+  onClick,
+  className,
+}: TableCellProps) {
   const Component = header ? 'th' : 'td';
   return (
     <Component
@@ -16,8 +24,10 @@ export function TableCell({ children, header = false, align = 'left' }: TableCel
         !header && 'text-sm',
         align === 'left' && 'text-left',
         align === 'center' && 'text-center',
-        align === 'right' && 'text-right'
+        align === 'right' && 'text-right',
+        className
       )}
+      onClick={onClick}
     >
       {children}
     </Component>


### PR DESCRIPTION
## 概要
Issue #44 の明細テーブルコンポーネントを実装

## 変更内容
- `TransactionTable`: 日付・金額ソート、ページネーション付き明細テーブル
- `TablePagination`: 前へ/次へボタンとページ情報表示
- `TableCell`に`onClick`と`className`propsを追加

## テスト
- 5件のテストを追加
- 全432テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)