### PR TITLE
feat(RankingList/HighExpenseList): ランキング・高額支出リスト実装 #45

### DIFF
--- a/src/components/dashboard/HighExpenseList/HighExpenseList.test.tsx
+++ b/src/components/dashboard/HighExpenseList/HighExpenseList.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HighExpenseList } from './HighExpenseList';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '高額商品A',
+    amount: -50000,
+    institution: 'テスト銀行',
+    category: '衣服美容',
+    subcategory: '洋服',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-16'),
+    description: '高額商品B',
+    amount: -30000,
+    institution: 'テスト銀行',
+    category: '健康医療',
+    subcategory: '医療費',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-3',
+    date: new Date('2025-01-17'),
+    description: '低額商品',
+    amount: -1000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('HighExpenseList', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+  });
+
+  it('タイトルが表示される', async () => {
+    render(<HighExpenseList />, { wrapper });
+    expect(await screen.findByText('高額支出')).toBeInTheDocument();
+  });
+
+  it('閾値を超える高額支出のみ表示される', async () => {
+    render(<HighExpenseList threshold={10000} />, { wrapper });
+    expect(await screen.findByText('高額商品A')).toBeInTheDocument();
+    expect(screen.getByText('高額商品B')).toBeInTheDocument();
+    expect(screen.queryByText('低額商品')).not.toBeInTheDocument();
+  });
+
+  it('金額がフォーマットされて表示される', async () => {
+    render(<HighExpenseList threshold={10000} />, { wrapper });
+    expect(await screen.findByText('-¥50,000')).toBeInTheDocument();
+  });
+
+  it('日付とカテゴリが表示される', async () => {
+    render(<HighExpenseList threshold={10000} />, { wrapper });
+    await screen.findByText('高額商品A');
+    expect(screen.getByText(/衣服美容/)).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/HighExpenseList/HighExpenseList.tsx
+++ b/src/components/dashboard/HighExpenseList/HighExpenseList.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { useFilteredData } from '@/hooks';
+import { Card, Amount } from '@/components/ui';
+import { formatDate } from '@/utils/formatters';
+import { getHighExpenses } from '@/utils/calculations';
+
+type HighExpenseListProps = {
+  threshold?: number;
+  limit?: number;
+};
+
+export function HighExpenseList({ threshold = 10000, limit = 10 }: HighExpenseListProps) {
+  const { data } = useFilteredData();
+
+  const highExpenses = useMemo(() => {
+    return getHighExpenses(data, threshold, limit);
+  }, [data, threshold, limit]);
+
+  return (
+    <Card title="高額支出">
+      <div className="space-y-2">
+        {highExpenses.length === 0 ? (
+          <p className="text-text-secondary text-sm">
+            ¥{threshold.toLocaleString()}を超える支出はありません
+          </p>
+        ) : (
+          highExpenses.map((t) => (
+            <div
+              key={t.id}
+              className="flex items-center justify-between py-2 border-b border-border last:border-0"
+            >
+              <div>
+                <div className="font-medium">{t.description}</div>
+                <div className="text-xs text-text-secondary">
+                  {formatDate(t.date)} • {t.category}
+                </div>
+              </div>
+              <Amount value={t.amount} size="sm" />
+            </div>
+          ))
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/HighExpenseList/index.ts
+++ b/src/components/dashboard/HighExpenseList/index.ts
@@ -1,0 +1,1 @@
+export { HighExpenseList } from './HighExpenseList';

--- a/src/components/dashboard/RankingList/RankingList.test.tsx
+++ b/src/components/dashboard/RankingList/RankingList.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RankingList } from './RankingList';
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import * as services from '@/services';
+import type { Transaction } from '@/types';
+
+vi.mock('@/services', () => ({
+  loadTransactions: vi.fn(),
+}));
+
+const mockTransactions: Transaction[] = [
+  {
+    id: 'test-1',
+    date: new Date('2025-01-15'),
+    description: '食料品購入',
+    amount: -5000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '食料品',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-2',
+    date: new Date('2025-01-16'),
+    description: '外食',
+    amount: -3000,
+    institution: 'テスト銀行',
+    category: '食費',
+    subcategory: '外食',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+  {
+    id: 'test-3',
+    date: new Date('2025-01-17'),
+    description: '電車代',
+    amount: -1000,
+    institution: 'テスト銀行',
+    category: '交通費',
+    subcategory: '電車',
+    memo: '',
+    isTransfer: false,
+    isCalculated: true,
+  },
+];
+
+describe('RankingList', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TransactionProvider>
+      <FilterProvider>{children}</FilterProvider>
+    </TransactionProvider>
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(services.loadTransactions).mockResolvedValue(mockTransactions);
+  });
+
+  it('タイトルが表示される', async () => {
+    render(<RankingList />, { wrapper });
+    expect(await screen.findByText('支出ランキング TOP10')).toBeInTheDocument();
+  });
+
+  it('ランキング順位が表示される', async () => {
+    render(<RankingList />, { wrapper });
+    expect(await screen.findByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('中項目名が表示される', async () => {
+    render(<RankingList />, { wrapper });
+    expect(await screen.findByText('食料品')).toBeInTheDocument();
+  });
+
+  it('金額がフォーマットされて表示される', async () => {
+    render(<RankingList limit={5} />, { wrapper });
+    // 負の金額として表示
+    expect(await screen.findByText('-¥5,000')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/RankingList/RankingList.tsx
+++ b/src/components/dashboard/RankingList/RankingList.tsx
@@ -1,0 +1,34 @@
+import { useRanking } from '@/hooks';
+import { Card, Amount, Badge, CategoryIcon } from '@/components/ui';
+import { formatPercentage } from '@/utils/formatters';
+
+type RankingListProps = {
+  limit?: number;
+};
+
+export function RankingList({ limit = 10 }: RankingListProps) {
+  const ranking = useRanking(limit);
+
+  return (
+    <Card title="支出ランキング TOP10">
+      <div className="space-y-3">
+        {ranking.map((item) => (
+          <div key={item.subcategory} className="flex items-center gap-3">
+            <Badge variant="default" size="sm">
+              {item.rank}
+            </Badge>
+            <CategoryIcon category={item.category} size="sm" />
+            <div className="flex-1 min-w-0">
+              <div className="font-medium truncate">{item.subcategory}</div>
+              <div className="text-xs text-text-secondary">{item.category}</div>
+            </div>
+            <div className="text-right">
+              <Amount value={-item.amount} size="sm" />
+              <div className="text-xs text-text-secondary">{formatPercentage(item.percentage)}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/dashboard/RankingList/index.ts
+++ b/src/components/dashboard/RankingList/index.ts
@@ -1,0 +1,1 @@
+export { RankingList } from './RankingList';

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,3 +1,5 @@
 export { SummaryCards, IncomeCard, ExpenseCard, BalanceCard } from './SummaryCards';
 export { FilterPanel, PeriodFilter, CategoryFilter, InstitutionFilter } from './FilterPanel';
 export { TransactionTable, TablePagination } from './TransactionTable';
+export { RankingList } from './RankingList';
+export { HighExpenseList } from './HighExpenseList';


### PR DESCRIPTION
## 概要
Issue #45 のランキングリストと高額支出リストコンポーネントを実装

## 変更内容
- `RankingList`: 中項目別支出ランキングTOP10表示
  - ランク番号、カテゴリアイコン、金額、パーセンテージ表示
- `HighExpenseList`: 閾値を超える高額支出一覧
  - 日付、内容、カテゴリ、金額表示
  - 閾値・件数を props で指定可能

## テスト
- 8件のテストを追加
- 全440テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)