### PR TITLE
feat(App): アプリエントリーポイント実装 #46

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>家計簿ダッシュボード</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,81 @@
+import { TransactionProvider, FilterProvider } from '@/contexts';
+import { Header, DashboardGrid, GridItem, Section } from '@/components/layout';
+import {
+  SummaryCards,
+  FilterPanel,
+  TransactionTable,
+  RankingList,
+  HighExpenseList,
+} from '@/components/dashboard';
+import {
+  MonthlyTrendChart,
+  CategoryPieChart,
+  CategoryBarChart,
+  InstitutionChart,
+  IncomeChart,
+  HeatmapChart,
+} from '@/components/charts';
+
+export function App() {
+  return (
+    <TransactionProvider>
+      <FilterProvider>
+        <div className="min-h-screen bg-background">
+          <Header />
+          <main className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+            {/* サマリー */}
+            <SummaryCards />
+
+            {/* フィルター */}
+            <div className="mt-6">
+              <FilterPanel />
+            </div>
+
+            {/* チャート */}
+            <Section title="収支分析" className="mt-8">
+              <DashboardGrid>
+                <GridItem colSpan={2}>
+                  <MonthlyTrendChart />
+                </GridItem>
+                <GridItem>
+                  <CategoryPieChart />
+                </GridItem>
+                <GridItem>
+                  <CategoryBarChart />
+                </GridItem>
+                <GridItem>
+                  <InstitutionChart />
+                </GridItem>
+                <GridItem>
+                  <IncomeChart />
+                </GridItem>
+              </DashboardGrid>
+            </Section>
+
+            {/* ランキング */}
+            <Section title="支出詳細" className="mt-8">
+              <DashboardGrid>
+                <GridItem>
+                  <RankingList />
+                </GridItem>
+                <GridItem>
+                  <HighExpenseList />
+                </GridItem>
+                <GridItem colSpan={3}>
+                  <HeatmapChart />
+                </GridItem>
+              </DashboardGrid>
+            </Section>
+
+            {/* 明細テーブル */}
+            <Section title="取引明細" className="mt-8">
+              <TransactionTable />
+            </Section>
+          </main>
+        </div>
+      </FilterProvider>
+    </TransactionProvider>
+  );
+}
+
+export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles/globals.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);


### PR DESCRIPTION
## 概要
Issue #46 のアプリケーションエントリーポイントを実装

## 変更内容
- `App.tsx`: 全コンポーネントを統合したダッシュボードレイアウト
  - TransactionProvider + FilterProviderでラップ
  - Header, SummaryCards, FilterPanel
  - 収支分析チャート（MonthlyTrend, CategoryPie, CategoryBar, Institution, Income）
  - 支出詳細（RankingList, HighExpenseList, HeatmapChart）
  - 明細テーブル（TransactionTable）
- `main.tsx`: React 19のcreateRootでアプリをマウント
- `index.html`: 日本語HTMLテンプレート

## テスト
- 全440テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)