### PR TITLE
feat: サマリーカードのサイズと視覚的強調を改善 (#94)

### DIFF
--- a/src/components/dashboard/SummaryCards/BalanceCard.tsx
+++ b/src/components/dashboard/SummaryCards/BalanceCard.tsx
@@ -14,9 +14,9 @@ export function BalanceCard() {
   const balance = income - expense;
 
   return (
-    <Card title="収支バランス" icon={Scale} accentColor="primary">
-      <Amount value={balance} size="lg" />
-      <div className="mt-2">
+    <Card title="収支バランス" icon={Scale} accentColor="primary" size="large" highlighted>
+      <Amount value={balance} size="xl" />
+      <div className="mt-3">
         <TrendIndicator value={trend.balance} positiveIsGood />
       </div>
     </Card>

--- a/src/components/dashboard/SummaryCards/ExpenseCard.tsx
+++ b/src/components/dashboard/SummaryCards/ExpenseCard.tsx
@@ -12,9 +12,9 @@ export function ExpenseCard() {
   const expense = calcExpense(data);
 
   return (
-    <Card title="月間支出" icon={TrendingDown} accentColor="expense">
-      <Amount value={-expense} size="lg" />
-      <div className="mt-2">
+    <Card title="月間支出" icon={TrendingDown} accentColor="expense" size="large" highlighted>
+      <Amount value={-expense} size="xl" />
+      <div className="mt-3">
         <TrendIndicator value={trend.expense} positiveIsGood={false} />
       </div>
     </Card>

--- a/src/components/dashboard/SummaryCards/IncomeCard.tsx
+++ b/src/components/dashboard/SummaryCards/IncomeCard.tsx
@@ -12,9 +12,9 @@ export function IncomeCard() {
   const income = calcIncome(data);
 
   return (
-    <Card title="月間収入" icon={TrendingUp} accentColor="income">
-      <Amount value={income} size="lg" />
-      <div className="mt-2">
+    <Card title="月間収入" icon={TrendingUp} accentColor="income" size="large" highlighted>
+      <Amount value={income} size="xl" />
+      <div className="mt-3">
         <TrendIndicator value={trend.income} positiveIsGood />
       </div>
     </Card>

--- a/src/components/dashboard/SummaryCards/SummaryCards.tsx
+++ b/src/components/dashboard/SummaryCards/SummaryCards.tsx
@@ -8,7 +8,7 @@ import { BalanceCard } from './BalanceCard';
  */
 export function SummaryCards() {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       <IncomeCard />
       <ExpenseCard />
       <BalanceCard />

--- a/src/components/ui/Amount/Amount.tsx
+++ b/src/components/ui/Amount/Amount.tsx
@@ -5,7 +5,7 @@ type AmountProps = {
   /** 金額（正: 収入、負: 支出） */
   value: number;
   /** サイズ */
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
   /** 符号を表示するか（デフォルト: true） */
   showSign?: boolean;
   /** カスタムクラス */
@@ -16,6 +16,7 @@ const sizeClasses = {
   sm: 'text-sm',
   md: 'text-base',
   lg: 'text-2xl font-bold',
+  xl: 'text-3xl font-bold tracking-tight',
 } as const;
 
 /**

--- a/src/components/ui/Card/Card.tsx
+++ b/src/components/ui/Card/Card.tsx
@@ -7,17 +7,35 @@ type CardProps = {
   children: React.ReactNode;
   className?: string;
   accentColor?: 'income' | 'expense' | 'primary';
+  /** カードサイズ（largeは大きなパディング） */
+  size?: 'default' | 'large';
+  /** 背景色を薄く強調表示 */
+  highlighted?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-export function Card({ title, icon: Icon, children, className, accentColor, ...props }: CardProps) {
+export function Card({
+  title,
+  icon: Icon,
+  children,
+  className,
+  accentColor,
+  size = 'default',
+  highlighted = false,
+  ...props
+}: CardProps) {
   return (
     <div
       className={cn(
-        'bg-surface rounded-lg shadow-md p-6',
+        'bg-surface rounded-lg shadow-md',
         'hover:shadow-lg transition-shadow',
+        size === 'default' && 'p-6',
+        size === 'large' && 'p-8',
         accentColor === 'income' && 'border-l-4 border-income',
         accentColor === 'expense' && 'border-l-4 border-expense',
         accentColor === 'primary' && 'border-l-4 border-primary',
+        highlighted && accentColor === 'income' && 'bg-income-light',
+        highlighted && accentColor === 'expense' && 'bg-expense-light',
+        highlighted && accentColor === 'primary' && 'bg-primary/5',
         className
       )}
       {...props}
@@ -26,7 +44,7 @@ export function Card({ title, icon: Icon, children, className, accentColor, ...p
         <h3 className="text-text-secondary text-sm font-medium mb-2 flex items-center gap-2">
           {Icon && (
             <Icon
-              size={16}
+              size={size === 'large' ? 20 : 16}
               className={cn(
                 accentColor === 'income' && 'text-income',
                 accentColor === 'expense' && 'text-expense',


### PR DESCRIPTION
## Summary
- Cardコンポーネントに`size`プロパティ（default/large）を追加し、大きなパディングに対応
- Cardコンポーネントに`highlighted`プロパティを追加し、背景色の薄い強調表示に対応
- Amountコンポーネントに`xl`サイズを追加（より大きなフォント）
- サマリーカード（Income/Expense/Balance）を大きなサイズと強調表示で更新
- グリッド間隔をgap-4からgap-6に増加

Closes #94

## Test plan
- [x] ダッシュボードでサマリーカードが大きく表示されることを確認
- [x] 背景色が薄く強調表示されることを確認
- [x] 金額表示が大きく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)