### PR TITLE
feat: 前月比変動率の表示を改善 (#95)

### DIFF
--- a/src/components/ui/Trend/TrendIndicator.tsx
+++ b/src/components/ui/Trend/TrendIndicator.tsx
@@ -3,12 +3,14 @@ import { cn } from '@/utils';
 import { formatPercentage } from '@/utils/formatters';
 
 type TrendIndicatorProps = {
-  /** 変化率 (0.05 = +5%) */
-  value: number;
+  /** 変化率 (0.05 = +5%)、nullまたはundefinedの場合はデータなし */
+  value: number | null | undefined;
   /** サイズ */
   size?: 'sm' | 'md';
   /** true: 増加が良い（収入）, false: 増加が悪い（支出） */
   positiveIsGood?: boolean;
+  /** 「前月比」ラベルを表示するか */
+  showLabel?: boolean;
   /** カスタムクラス */
   className?: string;
 } & React.HTMLAttributes<HTMLSpanElement>;
@@ -20,17 +22,20 @@ export function TrendIndicator({
   value,
   size = 'md',
   positiveIsGood = true,
+  showLabel = true,
   className,
   ...props
 }: TrendIndicatorProps) {
-  const isPositive = value > 0;
-  const isNeutral = value === 0;
+  const hasData = value !== null && value !== undefined && isFinite(value);
+  const isPositive = hasData && value > 0;
+  const isNeutral = hasData && value === 0;
 
   // 増加が良いか悪いかで色を決定
   const isGood = positiveIsGood ? isPositive : !isPositive && !isNeutral;
-  const colorClass = isNeutral ? 'text-text-secondary' : isGood ? 'text-income' : 'text-expense';
+  const colorClass =
+    !hasData || isNeutral ? 'text-text-secondary' : isGood ? 'text-income' : 'text-expense';
 
-  const Icon = isNeutral ? Minus : isPositive ? TrendingUp : TrendingDown;
+  const Icon = !hasData || isNeutral ? Minus : isPositive ? TrendingUp : TrendingDown;
   const iconSize = size === 'sm' ? 12 : 16;
 
   return (
@@ -44,8 +49,9 @@ export function TrendIndicator({
       )}
       {...props}
     >
+      {showLabel && <span className="text-text-secondary mr-1">前月比</span>}
       <Icon size={iconSize} />
-      {formatPercentage(Math.abs(value))}
+      {hasData ? formatPercentage(Math.abs(value)) : '-'}
     </span>
   );
 }

--- a/src/hooks/useTrend.ts
+++ b/src/hooks/useTrend.ts
@@ -5,16 +5,16 @@ import type { TrendData } from '@/types';
 
 /**
  * 前月比を計算
- * @returns 収入・支出・収支の変化率
+ * @returns 収入・支出・収支の変化率（nullは比較不可）
  */
 export function useTrend(): TrendData {
   const { transactions } = useTransactionContext();
   const { filters } = useFilterContext();
 
   return useMemo(() => {
-    // 全期間の場合は比較できないので0を返す
+    // 全期間の場合は比較できないのでnullを返す
     if (filters.month === 'all') {
-      return { income: 0, expense: 0, balance: 0 };
+      return { income: null, expense: null, balance: null };
     }
 
     const currentMonth = filters.month;
@@ -42,12 +42,21 @@ export function useTrend(): TrendData {
       return tYear === previousYear && tMonth === previousMonth;
     });
 
+    // 前月データが存在するかチェック
+    const hasPreviousData = previousTransactions.length > 0;
+
     // 収入・支出を計算
     const currentIncome = calcIncome(currentTransactions);
     const currentExpense = calcExpense(currentTransactions);
     const previousIncome = calcIncome(previousTransactions);
     const previousExpense = calcExpense(previousTransactions);
 
-    return calcTrend(currentIncome, currentExpense, previousIncome, previousExpense);
+    return calcTrend(
+      currentIncome,
+      currentExpense,
+      previousIncome,
+      previousExpense,
+      hasPreviousData
+    );
   }, [transactions, filters.year, filters.month]);
 }

--- a/src/types/summary.ts
+++ b/src/types/summary.ts
@@ -56,12 +56,13 @@ export type RankingItem = {
 
 /**
  * トレンドデータ（前月比）
+ * nullの場合は前月データがないことを示す
  */
 export type TrendData = {
-  /** 収入の変化率 */
-  income: number;
-  /** 支出の変化率 */
-  expense: number;
-  /** 収支の変化率 */
-  balance: number;
+  /** 収入の変化率（nullは前月データなし） */
+  income: number | null;
+  /** 支出の変化率（nullは前月データなし） */
+  expense: number | null;
+  /** 収支の変化率（nullは前月データなし） */
+  balance: number | null;
 };

--- a/src/utils/calculations/comparison.ts
+++ b/src/utils/calculations/comparison.ts
@@ -2,10 +2,21 @@ import type { TrendData } from '@/types';
 
 /**
  * 前月比を計算
- * @returns 変化率 (0.05 = +5%)
+ * @returns 変化率 (0.05 = +5%)、前月データがない場合はnull
  */
-export function calcMonthOverMonth(current: number, previous: number): number {
+export function calcMonthOverMonth(
+  current: number,
+  previous: number,
+  hasPreviousData: boolean = true
+): number | null {
+  if (!hasPreviousData) {
+    return null;
+  }
   if (previous === 0) {
+    // 前月が0で今月が0以外の場合は無限大の変化なのでnull
+    if (current !== 0) {
+      return null;
+    }
     return 0;
   }
   return (current - previous) / Math.abs(previous);
@@ -29,20 +40,22 @@ export function calcGrowthRate(values: number[]): number {
 
 /**
  * トレンドデータを計算（収入・支出・収支の変化率）
+ * @param hasPreviousData 前月データが存在するかどうか
  */
 export function calcTrend(
   currentIncome: number,
   currentExpense: number,
   previousIncome: number,
-  previousExpense: number
+  previousExpense: number,
+  hasPreviousData: boolean = true
 ): TrendData {
   const currentBalance = currentIncome - currentExpense;
   const previousBalance = previousIncome - previousExpense;
 
   return {
-    income: calcMonthOverMonth(currentIncome, previousIncome),
-    expense: calcMonthOverMonth(currentExpense, previousExpense),
-    balance: calcMonthOverMonth(currentBalance, previousBalance),
+    income: calcMonthOverMonth(currentIncome, previousIncome, hasPreviousData),
+    expense: calcMonthOverMonth(currentExpense, previousExpense, hasPreviousData),
+    balance: calcMonthOverMonth(currentBalance, previousBalance, hasPreviousData),
   };
 }
 


### PR DESCRIPTION
## Summary
- TrendIndicatorコンポーネントに「前月比」ラベルを追加
- 前月データがない場合（全期間表示時など）に「-」を表示
- TrendData型をnull許容に変更し、比較不可能なケースを適切に処理
- calcMonthOverMonth関数を更新し、前月データの有無を考慮

Closes #95

## Test plan
- [x] 12月を選択すると「前月比 ↗ 185.7%」などのラベル付き表示を確認
- [x] 「全期間」を選択すると「前月比 - 」が表示されることを確認
- [x] 収入増加は緑色、支出増加は赤色で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)