### PR TITLE
fix: 高額支出リストの文字切れを修正

### DIFF
--- a/src/components/dashboard/HighExpenseList/HighExpenseList.tsx
+++ b/src/components/dashboard/HighExpenseList/HighExpenseList.tsx
@@ -27,15 +27,17 @@ export function HighExpenseList({ threshold = 10000, limit = 10 }: HighExpenseLi
           highExpenses.map((t) => (
             <div
               key={t.id}
-              className="flex items-center justify-between py-2 border-b border-border last:border-0"
+              className="flex items-center justify-between py-2 border-b border-border last:border-0 gap-2"
             >
-              <div>
-                <div className="font-medium">{t.description}</div>
+              <div className="min-w-0 flex-1">
+                <div className="font-medium truncate" title={t.description}>
+                  {t.description}
+                </div>
                 <div className="text-xs text-text-secondary">
                   {formatDate(t.date)} • {t.category}
                 </div>
               </div>
-              <Amount value={t.amount} size="sm" />
+              <Amount value={t.amount} size="sm" className="flex-shrink-0" />
             </div>
           ))
         )}


### PR DESCRIPTION
## Summary
- truncateクラスで長いテキストを省略表示
- title属性でホバー時に全文をツールチップ表示
- flex layoutを改善してテキストが適切に収まるように

## Test plan
- [x] 型チェック通過
- [x] 高額支出リストで長いテキストが省略表示されることを確認
- [x] マウスホバーで全文がツールチップとして表示されることを確認

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)