### PR TITLE
fix: 取引明細の内容列の幅を改善

### DIFF
--- a/src/components/dashboard/TransactionTable/TransactionTable.tsx
+++ b/src/components/dashboard/TransactionTable/TransactionTable.tsx
@@ -62,13 +62,17 @@ export function TransactionTable() {
         <tbody>
           {paginatedData.map((t) => (
             <TableRow key={t.id}>
-              <TableCell>{formatDate(t.date)}</TableCell>
-              <TableCell>{t.description}</TableCell>
-              <TableCell>
+              <TableCell className="whitespace-nowrap">{formatDate(t.date)}</TableCell>
+              <TableCell className="max-w-md">
+                <span className="line-clamp-2" title={t.description}>
+                  {t.description}
+                </span>
+              </TableCell>
+              <TableCell className="whitespace-nowrap">
                 {t.category} / {t.subcategory}
               </TableCell>
-              <TableCell>{t.institution}</TableCell>
-              <TableCell align="right">
+              <TableCell className="whitespace-nowrap">{t.institution}</TableCell>
+              <TableCell align="right" className="whitespace-nowrap">
                 <Amount value={t.amount} size="sm" />
               </TableCell>
             </TableRow>


### PR DESCRIPTION
## Summary
- 内容列にmax-w-mdを追加して列幅を拡大
- line-clamp-2で最大2行表示に変更
- title属性でホバー時に全文をツールチップ表示
- 他の列にwhitespace-nowrapを追加して折り返し防止

## Test plan
- [x] 型チェック通過
- [x] 長い商品名が2行で表示されることを確認
- [x] ホバーで全文がツールチップ表示されることを確認
- [x] テーブル全体のレイアウトが崩れないことを確認

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)