### PR TITLE
feat: セクションヘッダーにアクセントバーとボーダーを追加

### DIFF
--- a/src/components/layout/Section/Section.tsx
+++ b/src/components/layout/Section/Section.tsx
@@ -16,12 +16,15 @@ export function Section({ title, description, children, className, ...props }: S
   const headingId = useId();
 
   return (
-    <section className={cn('space-y-4', className)} aria-labelledby={headingId} {...props}>
-      <div>
-        <h2 id={headingId} className="text-xl font-semibold text-text-primary">
-          {title}
-        </h2>
-        {description && <p className="text-sm text-text-secondary mt-1">{description}</p>}
+    <section className={cn('space-y-6', className)} aria-labelledby={headingId} {...props}>
+      <div className="flex items-center gap-3 pb-3 border-b-2 border-border">
+        <div className="w-1.5 h-7 bg-primary rounded-sm" />
+        <div>
+          <h2 id={headingId} className="text-xl font-bold text-text-primary">
+            {title}
+          </h2>
+          {description && <p className="text-sm text-text-secondary mt-0.5">{description}</p>}
+        </div>
       </div>
       {children}
     </section>


### PR DESCRIPTION
## Summary
- セクションタイトル左に緑のアクセントバー（`w-1.5 h-7 bg-primary`）を追加
- セクションヘッダー下に2px幅のボーダー（`border-b-2 border-border`）を追加
- セクション間の間隔を`space-y-4`から`space-y-6`に拡大
- タイトルフォントを`semibold`から`bold`に変更

## 受け入れ条件の確認
- [x] 各グラフがカード形式で表示される（ChartContainerで既に対応済み）
- [x] セクション間の境界が明確（アクセントバーとボーダーで実現）
- [x] カードにホバーエフェクトがある（Card.tsxで既に対応済み）
- [x] レスポンシブでカードが適切にリフローする

## Test plan
- [x] ダッシュボードで各セクションヘッダーにアクセントバーが表示される
- [x] セクションヘッダー下にボーダーが表示される
- [x] Playwrightでスクリーンショット検証済み

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)