### PR TITLE
feat: チャートにカスタムツールチップを追加

### DIFF
--- a/src/components/charts/CategoryBarChart/CategoryBarChart.tsx
+++ b/src/components/charts/CategoryBarChart/CategoryBarChart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'recharts';
 import { useCategorySummary } from '@/hooks';
 import { ChartContainer } from '../ChartContainer';
+import { BarChartTooltip } from '../shared';
 
 /**
  * カテゴリ別支出の横棒グラフ
@@ -28,10 +29,7 @@ export function CategoryBarChart() {
             tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`}
           />
           <YAxis type="category" dataKey="category" tick={{ fontSize: 12 }} width={80} />
-          <Tooltip
-            formatter={(value: number) => `¥${value.toLocaleString()}`}
-            contentStyle={{ borderRadius: 8 }}
-          />
+          <Tooltip content={<BarChartTooltip />} />
           <Bar dataKey="amount" name="支出">
             {data.map((entry, index) => (
               <Cell key={`cell-${index}`} fill={entry.color} />

--- a/src/components/charts/CategoryPieChart/CategoryPieChart.tsx
+++ b/src/components/charts/CategoryPieChart/CategoryPieChart.tsx
@@ -1,6 +1,7 @@
 import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recharts';
 import { useCategorySummary } from '@/hooks';
 import { ChartContainer } from '../ChartContainer';
+import { PieChartTooltip } from '../shared';
 import type { Props as LegendProps } from 'recharts/types/component/DefaultLegendContent';
 
 /**
@@ -50,10 +51,7 @@ export function CategoryPieChart() {
               <Cell key={`cell-${index}`} fill={entry.color} />
             ))}
           </Pie>
-          <Tooltip
-            formatter={(value: number) => `¥${value.toLocaleString()}`}
-            contentStyle={{ borderRadius: 8 }}
-          />
+          <Tooltip content={<PieChartTooltip />} />
           <Legend content={<CustomLegend />} />
         </PieChart>
       </ResponsiveContainer>

--- a/src/components/charts/IncomeChart/IncomeChart.tsx
+++ b/src/components/charts/IncomeChart/IncomeChart.tsx
@@ -3,6 +3,7 @@ import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from 'recha
 import { useFilteredData } from '@/hooks';
 import { ChartContainer } from '../ChartContainer';
 import { CATEGORIES } from '@/constants';
+import { IncomePieChartTooltip } from '../shared';
 
 // 収入用カラーパレット（緑系を中心に）
 const INCOME_COLORS = [
@@ -60,10 +61,7 @@ export function IncomeChart() {
               <Cell key={`cell-${index}`} fill={INCOME_COLORS[index % INCOME_COLORS.length]} />
             ))}
           </Pie>
-          <Tooltip
-            formatter={(value: number) => `¥${value.toLocaleString()}`}
-            contentStyle={{ borderRadius: 8 }}
-          />
+          <Tooltip content={<IncomePieChartTooltip />} />
           <Legend />
         </PieChart>
       </ResponsiveContainer>

--- a/src/components/charts/InstitutionChart/InstitutionChart.tsx
+++ b/src/components/charts/InstitutionChart/InstitutionChart.tsx
@@ -11,6 +11,7 @@ import {
 import { useInstitutionSummary } from '@/hooks';
 import { ChartContainer } from '../ChartContainer';
 import { CATEGORIES } from '@/constants';
+import { BarChartTooltip } from '../shared';
 
 // カテゴリ色の配列を生成
 const INSTITUTION_COLORS = Object.values(CATEGORIES).map((c) => c.color);
@@ -32,10 +33,7 @@ export function InstitutionChart() {
             tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`}
           />
           <YAxis type="category" dataKey="institution" tick={{ fontSize: 11 }} width={120} />
-          <Tooltip
-            formatter={(value: number) => `¥${value.toLocaleString()}`}
-            contentStyle={{ borderRadius: 8 }}
-          />
+          <Tooltip content={<BarChartTooltip />} />
           <Bar dataKey="amount" name="支出">
             {data.map((_, index) => (
               <Cell

--- a/src/components/charts/MonthlyTrendChart/MonthlyTrendChart.tsx
+++ b/src/components/charts/MonthlyTrendChart/MonthlyTrendChart.tsx
@@ -11,6 +11,7 @@ import {
 import { useMonthlySummary } from '@/hooks';
 import { ChartContainer } from '../ChartContainer';
 import { CHART_COLORS } from '@/constants';
+import { LineChartTooltip } from '../shared';
 
 /**
  * 月別収支推移の折れ線グラフ
@@ -25,10 +26,7 @@ export function MonthlyTrendChart() {
           <CartesianGrid strokeDasharray="3 3" stroke="#E5E1D8" />
           <XAxis dataKey="month" tick={{ fontSize: 12 }} />
           <YAxis tick={{ fontSize: 12 }} tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`} />
-          <Tooltip
-            formatter={(value: number) => `¥${value.toLocaleString()}`}
-            contentStyle={{ borderRadius: 8 }}
-          />
+          <Tooltip content={<LineChartTooltip />} />
           <Legend />
           <Line
             type="monotone"

--- a/src/components/charts/SubcategoryChart/SubcategoryChart.tsx
+++ b/src/components/charts/SubcategoryChart/SubcategoryChart.tsx
@@ -3,6 +3,7 @@ import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Toolti
 import { useFilteredData } from '@/hooks';
 import { ChartContainer } from '../ChartContainer';
 import { getCategoryColor } from '@/constants';
+import { BarChartTooltip } from '../shared';
 
 type SubcategoryChartProps = {
   category: string;
@@ -49,10 +50,7 @@ export function SubcategoryChart({ category, onBack }: SubcategoryChartProps) {
             tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`}
           />
           <YAxis type="category" dataKey="subcategory" tick={{ fontSize: 12 }} width={100} />
-          <Tooltip
-            formatter={(value: number) => `¥${value.toLocaleString()}`}
-            contentStyle={{ borderRadius: 8 }}
-          />
+          <Tooltip content={<BarChartTooltip />} />
           <Bar dataKey="amount" name="支出" fill={color} />
         </BarChart>
       </ResponsiveContainer>

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -6,3 +6,4 @@ export { SubcategoryChart } from './SubcategoryChart';
 export { InstitutionChart } from './InstitutionChart';
 export { IncomeChart } from './IncomeChart';
 export { HeatmapChart } from './HeatmapChart';
+export * from './shared';

--- a/src/components/charts/shared/CustomTooltip.tsx
+++ b/src/components/charts/shared/CustomTooltip.tsx
@@ -1,0 +1,201 @@
+import type { TooltipProps } from 'recharts';
+import { CHART_COLORS } from '@/constants';
+
+type TooltipPayload = {
+  name: string;
+  value: number;
+  color?: string;
+  dataKey?: string;
+  payload?: {
+    category?: string;
+    subcategory?: string;
+    institution?: string;
+    percentage?: number;
+    month?: string;
+    income?: number;
+    expense?: number;
+    balance?: number;
+    amount?: number;
+    color?: string;
+  };
+};
+
+type CustomTooltipProps = TooltipProps<number, string> & {
+  payload?: TooltipPayload[];
+};
+
+/**
+ * 金額をフォーマット
+ */
+function formatAmount(value: number): string {
+  return `¥${Math.abs(value).toLocaleString()}`;
+}
+
+/**
+ * 折れ線グラフ用ツールチップ
+ * 月、収入/支出/収支の金額を表示
+ */
+export function LineChartTooltip({ active, payload, label }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const labelMap: Record<string, string> = {
+    income: '収入',
+    expense: '支出',
+    balance: '収支',
+  };
+
+  const colorMap: Record<string, string> = {
+    income: CHART_COLORS.income,
+    expense: CHART_COLORS.expense,
+    balance: CHART_COLORS.balance,
+  };
+
+  return (
+    <div className="bg-surface border border-border rounded-lg shadow-lg p-3 min-w-[140px]">
+      <p className="text-sm font-semibold text-text-primary mb-2 border-b border-border pb-2">
+        {label}
+      </p>
+      <div className="space-y-1">
+        {payload.map((entry, index) => {
+          const dataKey = entry.dataKey as string;
+          const value = entry.value ?? 0;
+          return (
+            <div key={index} className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-2">
+                <span
+                  className="w-2.5 h-2.5 rounded-full"
+                  style={{ backgroundColor: colorMap[dataKey] || entry.color }}
+                />
+                <span className="text-sm text-text-secondary">
+                  {labelMap[dataKey] || entry.name}
+                </span>
+              </div>
+              <span
+                className="text-sm font-medium tabular-nums"
+                style={{ color: colorMap[dataKey] || entry.color }}
+              >
+                {formatAmount(value)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 円グラフ用ツールチップ
+ * カテゴリ名、金額、割合を表示
+ */
+export function PieChartTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const data = payload[0]!;
+  const category = data.name || data.payload?.category || '';
+  const amount = data.value ?? data.payload?.amount ?? 0;
+  const percentage = data.payload?.percentage ?? 0;
+  const color = data.payload?.color || data.color || CHART_COLORS.expense;
+
+  return (
+    <div className="bg-surface border border-border rounded-lg shadow-lg p-3 min-w-[160px]">
+      <div className="flex items-center gap-2 mb-2 pb-2 border-b border-border">
+        <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+        <span className="text-sm font-semibold text-text-primary">{category}</span>
+      </div>
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-sm text-text-secondary">金額</span>
+          <span className="text-sm font-medium text-text-primary tabular-nums">
+            {formatAmount(amount)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-sm text-text-secondary">割合</span>
+          <span className="text-sm font-medium text-text-primary tabular-nums">
+            {(percentage * 100).toFixed(1)}%
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 棒グラフ用ツールチップ
+ * カテゴリ名/サブカテゴリ名/金融機関名、金額を表示
+ */
+export function BarChartTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const data = payload[0]!;
+  // category, subcategory, institution のいずれかを取得
+  const label =
+    data.payload?.category ||
+    data.payload?.subcategory ||
+    data.payload?.institution ||
+    data.name ||
+    '';
+  const amount = data.value ?? data.payload?.amount ?? 0;
+  const color = data.payload?.color || data.color || CHART_COLORS.expense;
+
+  return (
+    <div className="bg-surface border border-border rounded-lg shadow-lg p-3 min-w-[140px]">
+      <div className="flex items-center gap-2 mb-2 pb-2 border-b border-border">
+        <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+        <span className="text-sm font-semibold text-text-primary">{label}</span>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-sm text-text-secondary">金額</span>
+        <span className="text-sm font-medium text-text-primary tabular-nums">
+          {formatAmount(amount)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 収入円グラフ用ツールチップ
+ * サブカテゴリ名、金額、割合を表示
+ */
+export function IncomePieChartTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const data = payload[0]!;
+  const label = data.name || data.payload?.subcategory || '';
+  const amount = data.value ?? data.payload?.amount ?? 0;
+  const percentage = data.payload?.percentage ?? 0;
+  const color = data.color || CHART_COLORS.income;
+
+  return (
+    <div className="bg-surface border border-border rounded-lg shadow-lg p-3 min-w-[160px]">
+      <div className="flex items-center gap-2 mb-2 pb-2 border-b border-border">
+        <span className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+        <span className="text-sm font-semibold text-text-primary">{label}</span>
+      </div>
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-sm text-text-secondary">金額</span>
+          <span className="text-sm font-medium text-text-primary tabular-nums">
+            {formatAmount(amount)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-sm text-text-secondary">割合</span>
+          <span className="text-sm font-medium text-text-primary tabular-nums">
+            {(percentage * 100).toFixed(1)}%
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/charts/shared/index.ts
+++ b/src/components/charts/shared/index.ts
@@ -1,0 +1,6 @@
+export {
+  LineChartTooltip,
+  PieChartTooltip,
+  BarChartTooltip,
+  IncomePieChartTooltip,
+} from './CustomTooltip';


### PR DESCRIPTION
## Summary
- 全チャートにカスタムツールチップを追加
  - 折れ線グラフ: 月、収入/支出/収支の金額を表示
  - 円グラフ: カテゴリ名、金額、割合を表示
  - 棒グラフ: カテゴリ名、金額を表示
- 共通のツールチップコンポーネントを`src/components/charts/shared/`に作成
- 色付きのインジケーターで視覚的に分かりやすく

## Test plan
- [x] 型チェック通過
- [x] 折れ線グラフでホバー時にツールチップが表示される
- [x] 円グラフでホバー時にツールチップが表示される
- [x] 棒グラフでホバー時にツールチップが表示される
- [x] 各ツールチップに正しい情報が表示される

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)