### PR TITLE
feat: 日別支出ウェーブチャートを追加

### DIFF
--- a/doc/daily_spending_wave_chart_spec.md
+++ b/doc/daily_spending_wave_chart_spec.md
@@ -1,0 +1,369 @@
+# 日別支出ウェーブチャート統合仕様書
+
+## 概要
+
+日別の支出データをカテゴリ別に積み上げエリアチャートで可視化するコンポーネント。
+`prototype/daily-spending-wave.html` を基に、既存のダッシュボードアーキテクチャに統合する。
+
+### 元プロトタイプの特徴
+
+- **チャートライブラリ**: Highcharts（積み上げエリアチャート）
+- **期間**: 90日間の日別データ
+- **カテゴリ**: Food, Fun, Transport, Daily Goods, Health, Utility
+- **インタラクション**: X軸ズーム、ホバーで詳細表示、凡例クリックでカテゴリ切替
+- **デザイン**: Scientific Comic スタイル（角丸、ダッシュ線グリッド）
+
+### 統合後の変更点
+
+| 項目 | プロトタイプ | 統合後 |
+|------|-------------|--------|
+| ライブラリ | Highcharts | **Recharts** |
+| 期間 | 固定90日 | **フィルター連動（月単位 or 全期間）** |
+| カテゴリ | 英語固定 | **TSVデータの大項目を使用** |
+| データ | モック生成 | **実データから集計** |
+| スタイル | Tailwind CDN | **既存テーマ（design_theme.md）** |
+
+---
+
+## コンポーネント仕様
+
+### ファイル配置
+
+```
+src/components/charts/DailySpendingChart/
+├── DailySpendingChart.tsx       # 本体
+├── DailySpendingChart.test.tsx  # テスト
+└── index.ts                     # 再エクスポート
+```
+
+### コンポーネント定義
+
+```typescript
+// DailySpendingChart.tsx
+import { ChartContainer } from '../ChartContainer';
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Brush } from 'recharts';
+
+type DailySpendingChartProps = {
+  /** X軸ズーム機能を有効にするか（デフォルト: true） */
+  enableZoom?: boolean;
+  /** 表示するカテゴリを限定（省略時は全カテゴリ） */
+  categories?: string[];
+  /** 高さ（px）（デフォルト: 500） */
+  height?: number;
+};
+
+export function DailySpendingChart({
+  enableZoom = true,
+  categories,
+  height = 500,
+}: DailySpendingChartProps);
+```
+
+### データ形式
+
+チャートが受け取るデータ形式（`useDailySpending` フックから取得）:
+
+```typescript
+type DailySpendingData = {
+  /** 日付（YYYY-MM-DD形式） */
+  date: string;
+  /** 曜日（"月", "火", ...） */
+  dayOfWeek: string;
+  /** カテゴリ別支出（キー: カテゴリ名、値: 金額） */
+  [category: string]: number | string;
+  /** 当日合計 */
+  total: number;
+};
+
+// 例
+{
+  date: "2025-12-01",
+  dayOfWeek: "月",
+  食費: 3500,
+  交通費: 800,
+  日用品: 1200,
+  total: 5500
+}
+```
+
+---
+
+## Hooks仕様
+
+### useDailySpending
+
+日別支出データを集計するカスタムフック。
+
+```typescript
+// src/hooks/useDailySpending.ts
+
+type UseDailySpendingReturn = {
+  /** 日別支出データ（日付順） */
+  data: DailySpendingData[];
+  /** 出現するカテゴリ一覧 */
+  categories: string[];
+  /** 期間合計 */
+  totalSpending: number;
+  /** 日平均 */
+  averageDaily: number;
+  /** 最大支出日 */
+  peakDay: { date: string; amount: number } | null;
+};
+
+function useDailySpending(): UseDailySpendingReturn;
+```
+
+### 実装要件
+
+1. **フィルター連動**: `useFilterContext` の year/month に基づいてデータを絞り込む
+2. **支出のみ**: `amount < 0` のトランザクションのみ対象
+3. **振替除外**: `isTransfer === true` は除外
+4. **計算対象のみ**: `isCalculated === true` のみ対象
+5. **カテゴリ集計**: 大項目（category）でグループ化
+6. **日付でソート**: 昇順でソート
+
+---
+
+## UIデザイン仕様
+
+### カラーパレット
+
+`constants/chartColors.ts` に追加:
+
+```typescript
+// 日別チャート用のカテゴリ色
+export const DAILY_CATEGORY_COLORS: Record<string, string> = {
+  食費: '#F43F5E',      // Sally Rose
+  趣味娯楽: '#FBBF24',  // Woodstock Yellow
+  交通費: '#38BDF8',    // Blanket Blue
+  日用品: '#A78BFA',    // Soft Purple
+  健康医療: '#34D399',  // Mint Green
+  水道光熱費: '#FB923C', // Orange
+  // 既存のCATEGORY_COLORSとマージ可
+};
+```
+
+### チャートスタイル
+
+| 要素 | スタイル |
+|------|---------|
+| エリア透明度 | 0.85 |
+| 線幅 | 1px（白） |
+| グリッド | ダッシュ線（LongDash相当） |
+| グリッド色 | `#F3F4F6` |
+| クロスヘア | 1px ダッシュ線、`ink-black`（#1F2937） |
+| マーカー | デフォルト非表示、ホバー時のみ表示 |
+
+### ツールチップ
+
+```
+┌─────────────────────────────────┐
+│ 2025.12.25 (木)                 │
+├─────────────────────────────────┤
+│ ● 食費:        ¥3,500           │
+│ ● 交通費:      ¥800             │
+│ ● 日用品:      ¥1,200           │
+├─────────────────────────────────┤
+│ 合計: ¥5,500                    │
+└─────────────────────────────────┘
+```
+
+- 背景: `rgba(255, 255, 255, 0.98)`
+- 角丸: 12px
+- シャドウ: `shadow-lg`
+- 日付フォーマット: `YYYY.MM.DD (曜日)`
+
+### ズーム機能（Brush）
+
+Rechartsの `<Brush>` コンポーネントでX軸ズームを実装:
+
+```typescript
+{enableZoom && (
+  <Brush
+    dataKey="date"
+    height={30}
+    stroke={CHART_COLORS.primary}
+    tickFormatter={(date) => formatDateShort(date)}
+  />
+)}
+```
+
+---
+
+## レイアウト配置
+
+### ダッシュボードでの位置
+
+月別収支推移チャートの下、カテゴリ別チャートの上に配置。
+
+```
+┌─────────────────────────────────────────┐
+│           サマリーカード                │
+├─────────────────────────────────────────┤
+│         月別収支推移チャート            │
+├─────────────────────────────────────────┤
+│      【日別支出ウェーブチャート】       │  ← 新規追加
+├───────────────────┬─────────────────────┤
+│ カテゴリ別円グラフ│  カテゴリ別棒グラフ │
+└───────────────────┴─────────────────────┘
+```
+
+### グリッド占有
+
+`DashboardGrid` で `span: 2`（全幅）を指定。
+
+```typescript
+<GridItem span={2}>
+  <DailySpendingChart />
+</GridItem>
+```
+
+---
+
+## インタラクション仕様
+
+### 1. ホバー
+
+- クロスヘア表示（X軸・Y軸の両方）
+- ツールチップ表示
+- 該当日のデータポイントをハイライト
+
+### 2. 凡例クリック
+
+- カテゴリの表示/非表示を切り替え
+- 非表示時は凡例テキストを薄くする
+
+### 3. ブラシ（ズーム）
+
+- チャート下部のブラシ領域をドラッグして期間を絞り込み
+- リセットボタンで全期間に戻す
+
+### 4. 日付クリック（オプション）
+
+- 日付をクリックすると、その日の明細をフィルター
+- `useFilterContext` と連携
+
+---
+
+## パフォーマンス考慮
+
+### データ量
+
+- 1年分 = 約365日 × カテゴリ数（10程度）= 3,650データポイント
+- Rechartsは1万点程度まで許容範囲
+
+### 最適化
+
+1. **メモ化**: `useMemo` でデータ変換を最適化
+2. **条件付きレンダリング**: データがない場合は空状態を表示
+3. **遅延読み込み**: 必要に応じて `React.lazy` で分割
+
+```typescript
+// useDailySpending.ts
+export function useDailySpending(): UseDailySpendingReturn {
+  const { data: transactions } = useFilteredData();
+
+  return useMemo(() => {
+    // 集計ロジック
+  }, [transactions]);
+}
+```
+
+---
+
+## テスト仕様
+
+### ユニットテスト（useDailySpending）
+
+```typescript
+describe('useDailySpending', () => {
+  it('日別に支出を集計する', () => {
+    // ...
+  });
+
+  it('収入トランザクションを除外する', () => {
+    // ...
+  });
+
+  it('振替トランザクションを除外する', () => {
+    // ...
+  });
+
+  it('フィルター（月）に連動する', () => {
+    // ...
+  });
+
+  it('カテゴリ一覧を返す', () => {
+    // ...
+  });
+});
+```
+
+### コンポーネントテスト（DailySpendingChart）
+
+```typescript
+describe('DailySpendingChart', () => {
+  it('チャートがレンダリングされる', () => {
+    render(<DailySpendingChart />);
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('凡例にカテゴリが表示される', () => {
+    render(<DailySpendingChart />);
+    expect(screen.getByText('食費')).toBeInTheDocument();
+  });
+
+  it('ズームを無効化できる', () => {
+    render(<DailySpendingChart enableZoom={false} />);
+    expect(document.querySelector('.recharts-brush')).not.toBeInTheDocument();
+  });
+
+  it('データがない場合は空状態を表示', () => {
+    // フィルターで空になるケース
+    render(<DailySpendingChart />);
+    expect(screen.getByText('表示するデータがありません')).toBeInTheDocument();
+  });
+});
+```
+
+---
+
+## 実装チェックリスト
+
+### Phase 1: データ層
+
+- [ ] `types/dailySpending.ts` - 型定義追加
+- [ ] `utils/calculations/dailySpending.ts` - 集計関数
+- [ ] `hooks/useDailySpending.ts` - カスタムフック
+- [ ] テスト作成・通過
+
+### Phase 2: UI層
+
+- [ ] `constants/chartColors.ts` - カテゴリ色追加
+- [ ] `components/charts/DailySpendingChart/` - コンポーネント
+- [ ] `components/charts/shared/DailyTooltip.tsx` - ツールチップ
+- [ ] テスト作成・通過
+
+### Phase 3: 統合
+
+- [ ] `App.tsx` にチャート追加
+- [ ] レイアウト調整
+- [ ] E2Eテスト（手動確認）
+
+---
+
+## 今後の拡張可能性
+
+1. **週末ハイライト**: 土日の背景色を変える
+2. **予算線**: 日別予算をラインで重ねる
+3. **アノテーション**: 特定日にマーカーを追加（給料日など）
+4. **比較モード**: 前月同期間との比較表示
+5. **エクスポート**: PNG/CSV出力機能
+
+---
+
+## 参考
+
+- [Recharts AreaChart ドキュメント](https://recharts.org/en-US/api/AreaChart)
+- [prototype/daily-spending-wave.html](../prototype/daily-spending-wave.html)
+- [既存チャートコンポーネント](../src/components/charts/)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/dashboard';
 import {
   MonthlyTrendChart,
+  DailySpendingChart,
   CategoryPieChart,
   CategoryBarChart,
   InstitutionChart,
@@ -43,6 +44,7 @@ export function App() {
               <Section title="収支分析" className="mt-8">
                 <ChartCarousel>
                   <MonthlyTrendChart />
+                  <DailySpendingChart />
                   <CategoryPieChart />
                   <CategoryBarChart />
                   <InstitutionChart />

--- a/src/components/charts/DailySpendingChart/DailySpendingChart.tsx
+++ b/src/components/charts/DailySpendingChart/DailySpendingChart.tsx
@@ -1,0 +1,203 @@
+import { useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  Brush,
+} from 'recharts';
+import { useDailySpending } from '@/hooks';
+import { ChartContainer } from '../ChartContainer';
+import { getDailyCategoryColor } from '@/constants';
+import { formatCurrency } from '@/utils';
+import type { DailySpendingData } from '@/types';
+
+type DailySpendingChartProps = {
+  /** Enable X-axis zoom via Brush (default: true) */
+  enableZoom?: boolean;
+  /** Chart height in px (default: 500) */
+  height?: number;
+};
+
+/**
+ * Format amount for tooltip
+ */
+function formatAmount(value: number): string {
+  return `¥${value.toLocaleString()}`;
+}
+
+/**
+ * Custom tooltip for daily spending chart
+ */
+function DailySpendingTooltip({
+  active,
+  payload,
+  label,
+  categories,
+}: {
+  active?: boolean;
+  payload?: Array<{ dataKey: string; value: number; color: string }>;
+  label?: string;
+  categories: string[];
+}) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  // Find the data point to get dayOfWeek
+  const dataPoint = payload[0] as unknown as { payload?: DailySpendingData };
+  const dayOfWeek = dataPoint?.payload?.dayOfWeek || '';
+  const total = dataPoint?.payload?.total || 0;
+
+  // Format date as YYYY.MM.DD
+  const formattedDate = label?.replace(/-/g, '.') || '';
+
+  return (
+    <div className="bg-surface/98 border border-border rounded-xl shadow-lg p-4 min-w-[180px]">
+      <p className="text-sm font-semibold text-text-primary mb-3 pb-2 border-b border-dashed border-border">
+        {formattedDate} ({dayOfWeek})
+      </p>
+      <div className="space-y-1.5">
+        {payload
+          .filter((entry) => categories.includes(entry.dataKey) && entry.value > 0)
+          .map((entry, index) => (
+            <div key={index} className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-2">
+                <span
+                  className="w-2.5 h-2.5 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span className="text-sm text-text-secondary">{entry.dataKey}</span>
+              </div>
+              <span className="text-sm font-medium tabular-nums text-text-primary">
+                {formatAmount(entry.value)}
+              </span>
+            </div>
+          ))}
+      </div>
+      <div className="mt-3 pt-2 border-t border-dashed border-border flex items-center justify-between">
+        <span className="text-sm font-semibold text-text-primary">合計</span>
+        <span className="text-sm font-bold tabular-nums text-text-primary">
+          {formatAmount(total)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Daily Spending Wave Chart
+ * Stacked area chart showing daily expenses by category
+ */
+export function DailySpendingChart({ enableZoom = true, height = 500 }: DailySpendingChartProps) {
+  const { data, categories, totalSpending, averageDaily, peakDay } = useDailySpending();
+
+  // Generate aria label for accessibility
+  const ariaLabel = useMemo(() => {
+    if (data.length === 0) {
+      return '日別支出ウェーブチャート。データがありません。';
+    }
+    return `日別支出ウェーブチャート。${data.length}日間のデータ。合計${formatCurrency(totalSpending)}、日平均${formatCurrency(averageDaily)}。${categories.length}カテゴリを表示。`;
+  }, [data.length, totalSpending, averageDaily, categories.length]);
+
+  // Format X-axis date label
+  const formatXAxis = (date: string) => {
+    const parts = date.split('-');
+    if (parts.length === 3 && parts[1] && parts[2]) {
+      return `${parseInt(parts[1])}/${parseInt(parts[2])}`;
+    }
+    return date;
+  };
+
+  if (data.length === 0) {
+    return (
+      <ChartContainer title="日別支出ウェーブ" height={height} aria-label={ariaLabel}>
+        <div className="flex items-center justify-center h-full text-text-secondary">
+          表示するデータがありません
+        </div>
+      </ChartContainer>
+    );
+  }
+
+  const description = peakDay
+    ? `最大支出日: ${peakDay.date.replace(/-/g, '/')} (${formatAmount(peakDay.amount)})`
+    : undefined;
+
+  return (
+    <ChartContainer
+      title="日別支出ウェーブ"
+      {...(description ? { description } : {})}
+      height={height}
+      aria-label={ariaLabel}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={data}
+          margin={{ top: 10, right: 30, left: 0, bottom: enableZoom ? 40 : 5 }}
+        >
+          <defs>
+            {categories.map((category) => {
+              const color = getDailyCategoryColor(category);
+              return (
+                <linearGradient
+                  key={category}
+                  id={`gradient-${category}`}
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop offset="5%" stopColor={color} stopOpacity={0.85} />
+                  <stop offset="95%" stopColor={color} stopOpacity={0.6} />
+                </linearGradient>
+              );
+            })}
+          </defs>
+          <CartesianGrid strokeDasharray="5 5" stroke="#E5E7EB" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatXAxis}
+            tick={{ fontSize: 11, fill: '#6B7280' }}
+            tickLine={{ stroke: '#E5E7EB' }}
+            axisLine={{ stroke: '#E5E7EB' }}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            tick={{ fontSize: 11, fill: '#6B7280' }}
+            tickFormatter={(v) => `¥${(v / 1000).toFixed(0)}K`}
+            tickLine={{ stroke: '#E5E7EB' }}
+            axisLine={{ stroke: '#E5E7EB' }}
+            width={60}
+          />
+          <Tooltip content={<DailySpendingTooltip categories={categories} />} />
+          <Legend wrapperStyle={{ paddingTop: 10 }} iconType="circle" iconSize={8} />
+          {categories.map((category) => (
+            <Area
+              key={category}
+              type="monotone"
+              dataKey={category}
+              stackId="1"
+              stroke={getDailyCategoryColor(category)}
+              strokeWidth={1}
+              fill={`url(#gradient-${category})`}
+              fillOpacity={1}
+            />
+          ))}
+          {enableZoom && (
+            <Brush
+              dataKey="date"
+              height={30}
+              stroke="#9CA3AF"
+              tickFormatter={formatXAxis}
+              startIndex={Math.max(0, data.length - 30)}
+            />
+          )}
+        </AreaChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/src/components/charts/DailySpendingChart/index.ts
+++ b/src/components/charts/DailySpendingChart/index.ts
@@ -1,0 +1,1 @@
+export { DailySpendingChart } from './DailySpendingChart';

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -1,5 +1,6 @@
 export { ChartContainer } from './ChartContainer';
 export { MonthlyTrendChart } from './MonthlyTrendChart';
+export { DailySpendingChart } from './DailySpendingChart';
 export { CategoryPieChart } from './CategoryPieChart';
 export { CategoryBarChart } from './CategoryBarChart';
 export { SubcategoryChart } from './SubcategoryChart';

--- a/src/constants/chartColors.ts
+++ b/src/constants/chartColors.ts
@@ -73,3 +73,30 @@ export const TEXT_COLORS = {
   tertiary: '#9CA3AF',
   onPrimary: '#1F2937', // Yellow背景上のテキストはダーク
 } as const;
+
+/**
+ * 日別支出チャート用カテゴリカラー
+ * Cozy Comic Theme
+ */
+export const DAILY_CATEGORY_COLORS: Record<string, string> = {
+  食費: '#F43F5E', // Sally Rose
+  '趣味・娯楽': '#FBBF24', // Woodstock Yellow
+  交通費: '#38BDF8', // Blanket Blue
+  日用品: '#A78BFA', // Soft Purple
+  '健康・医療': '#34D399', // Mint Green
+  '水道・光熱費': '#FB923C', // Orange
+  通信費: '#06B6D4', // Cyan
+  '教養・教育': '#10B981', // Emerald
+  '衣服・美容': '#F97316', // Deep Orange
+  交際費: '#EF4444', // Red
+  住宅: '#8B5CF6', // Violet
+  その他: '#6B7280', // Gray
+} as const;
+
+/**
+ * Get category color for daily spending chart
+ * Falls back to gray if category not found
+ */
+export function getDailyCategoryColor(category: string): string {
+  return DAILY_CATEGORY_COLORS[category] ?? '#6B7280';
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,6 +11,8 @@ export {
   SECONDARY_COLORS,
   BASE_COLORS,
   TEXT_COLORS,
+  DAILY_CATEGORY_COLORS,
+  getDailyCategoryColor,
 } from './chartColors';
 
 // 金融機関

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,3 +9,4 @@ export { useChartData } from './useChartData';
 export { useInsights } from './useInsights';
 export { useAnomalyDetection } from './useAnomalyDetection';
 export { useSavedFilters } from './useSavedFilters';
+export { useDailySpending } from './useDailySpending';

--- a/src/hooks/useDailySpending.ts
+++ b/src/hooks/useDailySpending.ts
@@ -1,0 +1,15 @@
+import { useMemo } from 'react';
+import { useFilteredData } from './useFilteredData';
+import { calcDailySpending } from '@/utils/calculations';
+import type { DailySpendingResult } from '@/types';
+
+/**
+ * 日別支出データを計算するフック
+ * FilterContextの状態に基づいてフィルタリングされたデータを使用
+ * @returns 日別支出データ
+ */
+export function useDailySpending(): DailySpendingResult {
+  const { data } = useFilteredData();
+
+  return useMemo(() => calcDailySpending(data), [data]);
+}

--- a/src/types/chart.ts
+++ b/src/types/chart.ts
@@ -49,3 +49,34 @@ export type HeatmapData = {
   /** 強度（0-1の正規化値） */
   intensity: number;
 };
+
+/**
+ * 日別支出チャート用データ
+ * カテゴリ名をキーとした動的プロパティを持つ
+ */
+export type DailySpendingData = {
+  /** 日付（YYYY-MM-DD形式） */
+  date: string;
+  /** 曜日（"月", "火", ...） */
+  dayOfWeek: string;
+  /** 当日合計 */
+  total: number;
+  /** カテゴリ別支出（動的プロパティ） */
+  [category: string]: number | string;
+};
+
+/**
+ * 日別支出フックの戻り値
+ */
+export type DailySpendingResult = {
+  /** 日別支出データ（日付順） */
+  data: DailySpendingData[];
+  /** 出現するカテゴリ一覧 */
+  categories: string[];
+  /** 期間合計 */
+  totalSpending: number;
+  /** 日平均 */
+  averageDaily: number;
+  /** 最大支出日 */
+  peakDay: { date: string; amount: number } | null;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,14 @@ export type {
 } from './summary';
 
 // Chart
-export type { MonthlyTrendData, PieChartData, BarChartData, HeatmapData } from './chart';
+export type {
+  MonthlyTrendData,
+  PieChartData,
+  BarChartData,
+  HeatmapData,
+  DailySpendingData,
+  DailySpendingResult,
+} from './chart';
 
 // Filter
 export type {

--- a/src/utils/calculations/dailySpending.ts
+++ b/src/utils/calculations/dailySpending.ts
@@ -1,0 +1,99 @@
+import type { Transaction, DailySpendingData, DailySpendingResult } from '@/types';
+
+const DAY_OF_WEEK: readonly string[] = ['日', '月', '火', '水', '木', '金', '土'];
+
+/**
+ * 日付をYYYY-MM-DD形式に変換
+ */
+function formatDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * 日付から曜日を取得
+ */
+function getDayOfWeek(date: Date): string {
+  return DAY_OF_WEEK[date.getDay()] ?? '?';
+}
+
+/**
+ * 日別支出データを計算
+ * @param transactions - トランザクション配列（フィルター適用済み）
+ * @returns 日別支出データ
+ */
+export function calcDailySpending(transactions: Transaction[]): DailySpendingResult {
+  // 支出のみを抽出（振替と計算対象外を除外）
+  const expenses = transactions.filter((t) => t.amount < 0 && !t.isTransfer && t.isCalculated);
+
+  if (expenses.length === 0) {
+    return {
+      data: [],
+      categories: [],
+      totalSpending: 0,
+      averageDaily: 0,
+      peakDay: null,
+    };
+  }
+
+  // 出現するカテゴリを収集
+  const categorySet = new Set<string>();
+  expenses.forEach((t) => categorySet.add(t.category));
+  const categories = Array.from(categorySet).sort();
+
+  // 日別にグループ化
+  const dailyMap = new Map<string, { date: Date; byCategory: Record<string, number> }>();
+
+  for (const t of expenses) {
+    const dateKey = formatDateKey(t.date);
+    const amount = Math.abs(t.amount);
+
+    if (!dailyMap.has(dateKey)) {
+      dailyMap.set(dateKey, { date: t.date, byCategory: {} });
+    }
+
+    const entry = dailyMap.get(dateKey)!;
+    entry.byCategory[t.category] = (entry.byCategory[t.category] || 0) + amount;
+  }
+
+  // DailySpendingData配列を作成
+  const data: DailySpendingData[] = Array.from(dailyMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, { date: dateObj, byCategory }]) => {
+      const total = Object.values(byCategory).reduce((sum, v) => sum + v, 0);
+      const result: DailySpendingData = {
+        date,
+        dayOfWeek: getDayOfWeek(dateObj),
+        total,
+      };
+
+      // カテゴリ別支出を追加（存在しないカテゴリは0）
+      for (const cat of categories) {
+        result[cat] = byCategory[cat] || 0;
+      }
+
+      return result;
+    });
+
+  // 統計情報を計算
+  const totalSpending = data.reduce((sum, d) => sum + d.total, 0);
+  const averageDaily = data.length > 0 ? totalSpending / data.length : 0;
+
+  // 最大支出日を探す
+  let peakDay: { date: string; amount: number } | null = null;
+  for (const d of data) {
+    if (!peakDay || d.total > peakDay.amount) {
+      peakDay = { date: d.date, amount: d.total };
+    }
+  }
+
+  return {
+    data,
+    categories,
+    totalSpending,
+    averageDaily,
+    peakDay,
+  };
+}

--- a/src/utils/calculations/index.ts
+++ b/src/utils/calculations/index.ts
@@ -18,3 +18,6 @@ export { calcInsights } from './insights';
 
 // Anomaly detection
 export { detectAnomalies, getAnomalyLabel } from './anomaly';
+
+// Daily spending
+export { calcDailySpending } from './dailySpending';


### PR DESCRIPTION
## Summary
- `DailySpendingChart` コンポーネントを新規作成
- 積み上げエリアチャートでカテゴリ別日別支出を可視化
- Brushによるズーム機能を実装
- `useDailySpending` フックで日別集計ロジックを実装
- カテゴリ別カラーパレットを追加
- 仕様書を `doc/daily_spending_wave_chart_spec.md` に追加

## Changes
- `src/components/charts/DailySpendingChart/` - チャートコンポーネント
- `src/hooks/useDailySpending.ts` - 日別支出集計フック
- `src/utils/calculations/dailySpending.ts` - 集計関数
- `src/types/chart.ts` - 型定義追加
- `src/constants/chartColors.ts` - カテゴリカラー追加

## Test plan
- [x] 型チェック通過
- [x] ビルド成功
- [ ] ダッシュボードで日別支出チャートが表示されることを確認
- [ ] ズーム機能が動作することを確認
- [ ] ツールチップにカテゴリ別支出と合計が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)